### PR TITLE
Add documentation site

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,28 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'deepcell-types'
+copyright = '2024, Van Valen Lab at the California Institute of Technology (Caltech)'
+author = 'Xuefei (Julie) Wang'
+release = '0.0.1-dev'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ['myst_nb']
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'pydata_sphinx_theme'
+html_static_path = ['_static']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,3 +26,4 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 html_theme = 'pydata_sphinx_theme'
 html_static_path = ['_static']
+html_title = "deepcell-types"

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,14 @@ DeepCell Types is a novel approach to cell phenotyping for spatial proteomics
 that addresses the challenge of generalization across diverse datasets with
 varying marker panels.
 
+For details on running the containerized workflow, see the [source repo][github].
+
 ```{toctree}
 ---
 maxdepth: 1
+hidden: true
 ---
+site/API-key
 ```
+
+[github]: https://github.com/vanvalenlab/deepcell-types?tab=readme-ov-file#how-to-use

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,12 @@
+deepcell-types documentation
+============================
+
+DeepCell Types is a novel approach to cell phenotyping for spatial proteomics
+that addresses the challenge of generalization across diverse datasets with
+varying marker panels.
+
+```{toctree}
+---
+maxdepth: 1
+---
+```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+pydata-sphinx-theme
+myst-nb

--- a/docs/site/API-key.md
+++ b/docs/site/API-key.md
@@ -1,0 +1,20 @@
+DeepCell API Key
+================
+
+DeepCell models and training datasets are licensed under a 
+[modified Apache license][license] for non-commercial academic use only.
+An API key for accessing datasets and models can be obtained at <https://users.deepcell.org/login/>.
+
+API Key Usage
+-------------
+
+The token that is issued by <https://users.deepcell.org> should be added as an
+environment variable::
+
+```bash
+export DEEPCELL_ACCESS_TOKEN=<token-from-users.deepcell.org>
+```
+
+This line can be added to your shell configuration (e.g. ``.bashrc``, ``.zshrc``,
+``.bash_profile``, etc.) to automatically grant access to DeepCell models/data
+upon login.


### PR DESCRIPTION
This will serve as the primary location for advertising the (authenticated) access to deepcell-types models/datasets.

The model/dataset hasn't been added yet (requires a bit more work on the auth side) but this will be the primary access portal.