### PR TITLE
Lazy patchify

### DIFF
--- a/deepcell_types/dataset.py
+++ b/deepcell_types/dataset.py
@@ -58,8 +58,6 @@ class PatchDataset(IterableDataset):
         self.channel_names_standard = channel_names_standard
         self.ch_idx = ch_idx
         self.raw = raw[~np.array(channel_masking), :, :]  # (C, H, W)
-
-        self._patchify()
         
 
     def _pad_images(self, sample):


### PR DESCRIPTION
Lazy patchify FOVs into samples. I replaced the default `Dataset` with random access permission with a `IteratableData` that connects smoothly to the original `patch_generator`. 

A simple test run showed it works. I haven't monitored compute resources to verify it achieves what we want. 

I wanted to open this PR sooner so that I can get feedback on whether makes sense or not before jumping into any rabbit holes. 