### PR TITLE
DOC: Add tutorial docs for inference pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+docs/site/extra_output
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,4 +29,5 @@ nb_execution_show_tb = True  # print tracebacks to stderr
 
 html_theme = 'pydata_sphinx_theme'
 html_static_path = ['_static']
+html_extra_path = ['site/extra_output']
 html_title = "deepcell-types"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,9 @@ extensions = ['myst_nb']
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+# Execution conf
+nb_execution_timeout = 300  # seconds
+nb_execution_show_tb = True  # print tracebacks to stderr
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ pip install git+https://github.com/vanvalenlab/deepcell-types@master
 maxdepth: 1
 hidden: true
 ---
+site/tutorial
 site/API-key
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,14 @@ For details on running the containerized workflow, see the [source repo][github]
 
 For access to models and datasets, see {doc}`site/API-key`.
 
+## Installation
+
+The development version of `deepcell-types` can be installed with `pip`:
+
+```bash
+pip install git+https://github.com/vanvalenlab/deepcell-types@master
+```
+
 ```{toctree}
 ---
 maxdepth: 1
@@ -17,4 +25,4 @@ hidden: true
 site/API-key
 ```
 
-[github]: https://github.com/vanvalenlab/deepcell-types?tab=readme-ov-file#how-to-use
+[github]: https://github.com/vanvalenlab/deepcell-types

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,7 @@
 sphinx
 pydata-sphinx-theme
 myst-nb
+# For tutorial
+napari
+pyqt6
+s3fs

--- a/docs/site/tutorial.md
+++ b/docs/site/tutorial.md
@@ -1,0 +1,73 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.1
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+# Tutorial
+
+The `deepcell-types` model predicts cell types from multiplexed spatial
+proteomic images.
+There are three main inputs to the cell type prediction pipeline:
+ 1. The multiplexed image in channels-first format
+ 2. A whole-cell segmentation mask for the image, and
+ 3. A mapping of the channel index to the marker expression name.
+
+Each of these components will be covered in further detail in this tutorial.
+
+## Example datasets
+
+This tutorial will make use of the spatial proteomic data provided by the
+[HuBMAP data portal][hubmap-data-portal].
+Users are encouraged to explore the portal for data of interest.
+For convenience, a subset of the publicly-available spatial proteomic data
+has been converted to a remote [zarr archive][zarr].
+The datasets in the zarr archive reflect the original HuBMAP indexing scheme
+(i.e. `HBM###_????_###`, where `#` indicates a number nad `?` indicates an
+upper-case alphabetical character).
+
+Interacting with the zarr hubmap data mirror requires a few additional
+dependencies:
+
+```bash
+pip install zarr\>2 s3fs rich
+```
+
+```{note}
+The hubmap data mirror uses zarr format v3, thus requires `zarr>2` to be
+installed.
+```
+
+### Exploring the archive
+
+```{code-cell}
+import zarr
+
+z = zarr.open_group(
+    store="s3://hubmap-mirror-demo/hubmap.zarr",
+    mode="r",
+    storage_options={
+        "anon": False,  # TODO: Make true when archive made public
+        "client_kwargs": dict(region_name="us-east-2"),
+    },
+)
+keys = list(z.group_keys())
+print(f"Number of datasets in the archive: {len(keys)}")
+```
+
+High-level structure of the data archive:
+
+```{code-cell}
+z.tree()
+```
+
+
+[hubmap-data-portal]: https://portal.hubmapconsortium.org/search/datasets
+[zarr]: https://zarr.readthedocs.io/en/stable/

--- a/docs/site/tutorial.md
+++ b/docs/site/tutorial.md
@@ -215,16 +215,40 @@ visualization.
 ```
 
 ```{code-cell}
+import napari
+nim = napari.Viewer(show=True)  # Headless for CI; set show=True for interactive viz
+
 # Compute contrast limits
-cl = [(min(ch), max(ch) for ch in img]
+cl = [(np.min(ch), np.max(ch)) for ch in img]
 
 # Visualize multiplex image
-nim = napari.view_image(img, channel_axis=0, name=chnames, contrast_limits=cl);
+nim.add_image(img, channel_axis=0, name=chnames, contrast_limits=cl);
 
 # Add segmentation mask
 mask_lyr = nim.add_labels(mask, name="CellSAM segmentation")
 mask_lyr.contour = 1
 ```
+
+```{code-cell}
+:tags: [hide-cell]
+
+# For static rendering - can safely be ignored if running notebook interactively
+from pathlib import Path
+
+screenshot_path = Path("extra_output/_generated")
+screenshot_path.mkdir(parents=True, exist_ok=True)
+nim.screenshot(
+    path=screenshot_path / "napari_img_and_segmentation.png",
+    canvas_only=False,
+);
+```
+
+<center>
+  <img src="../_generated/napari_img_and_segmentation.png"
+       alt="Napari window of multiplexed image and computed segmentation mask"
+       width=100%
+  />
+</center>
 
 
 ### Cell-type inference with `deepcell-types`

--- a/docs/site/tutorial.md
+++ b/docs/site/tutorial.md
@@ -232,7 +232,13 @@ With the system all configured, we can now run the pipeline:
 
 ```{code-cell}
 cell_types = deepcell_types.predict(
-    img, mask, chnames, mpp, model_name=model, device=device, num_workers=num_data_loader_threads
+    img.astype(np.float32),
+    mask.astype(np.float32),
+    chnames,
+    mpp,
+    model_name=model,
+    device_num=device,
+    num_workers=num_data_loader_threads,
 )
 ```
 

--- a/docs/site/tutorial.md
+++ b/docs/site/tutorial.md
@@ -303,6 +303,31 @@ df = pd.DataFrame.from_dict(  # For nice table rendering
 )
 ```
 
+```{code-cell}
+from collections import defaultdict
+
+# Convert the 1-1 `cell: type` mapping to a 1-many `type: list-of-cells` mapping
+labels_by_celltype = defaultdict(list)
+for idx, ct in idx_to_pred.items():
+    labels_by_celltype[ct].append(idx)
+```
+
+Here's the distribution of predicted cell types for this tissue:
+
+```{code-cell}
+from pprint import pprint
+num_cells = np.max(mask)
+print(f"Total number of cells: {num_cells}")
+
+pprint(
+    {
+        k: f"{len(v)} ({100 * len(v) / num_cells:02.2f}%)"
+        for k, v in labels_by_celltype.items()
+    },
+    sort_dicts=False,
+)
+```
+
 ### Visualizing the results
 
 There are many ways to visualize the cell-type prediction data, each with their own
@@ -312,13 +337,6 @@ The advantage of this approach is that individual layers can be toggled off to f
 on a particular cell type during interactive visualization.
 
 ```{code-cell}
-from collections import defaultdict
-
-# Convert the 1-1 `cell: type` mapping to a 1-many `type: list-of-cells` mapping
-labels_by_celltype = defaultdict(list)
-for idx, ct in idx_to_pred.items():
-    labels_by_celltype[ct].append(idx)
-
 # Regionprops to extract slices corresponding to each individual cell mask
 props = skimage.measure.regionprops(mask)
 prop_dict = {p.label: p for p in props}
@@ -353,7 +371,7 @@ nim.screenshot(
 
 <center>
   <img src="../_generated/napari_celltype_layers.png"
-       alt="Napari window of multiplexed image with celltype predictions
+       alt="Napari window of multiplexed image with celltype predictions"
        width=100%
   />
 </center>

--- a/docs/site/tutorial.md
+++ b/docs/site/tutorial.md
@@ -206,6 +206,27 @@ mask, _, _ = skimage.segmentation.relabel_sequential(mask)
 mask = mask.astype(np.uint32)
 ```
 
+### Visualizing results
+
+```{note}
+Multiplexed images and their analysis products are extremely information dense; users are
+strongly recommended to run tutorials locally to leverage `napari` for interactive
+visualization.
+```
+
+```{code-cell}
+# Compute contrast limits
+cl = [(min(ch), max(ch) for ch in img]
+
+# Visualize multiplex image
+nim = napari.view_image(img, channel_axis=0, name=chnames, contrast_limits=cl);
+
+# Add segmentation mask
+mask_lyr = nim.add_labels(mask, name="CellSAM segmentation")
+mask_lyr.contour = 1
+```
+
+
 ### Cell-type inference with `deepcell-types`
 
 We now have all the necessary components to run the cell-type inference pipeline.


### PR DESCRIPTION
Adds a tutorial demonstrating a complete cell-type inference pipeline, including cellSAM for cell segmentation.

A subset of the data are hosted in a publicly-accessible bucket. To start, I've chosen 3 datasets, one from each of three different tissue types (intestine, uterus, spleen) from the mirrored hubmap data.

Here's a preview of the rendered page: https://rossbar.github.io/deepcell-types/site/tutorial.html