### PR TITLE
Simplify tutorial generated image handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-docs/site/extra_output
+# Static images auto-generated during doc build
+docs/_static/_generated
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,5 +29,4 @@ nb_execution_show_tb = True  # print tracebacks to stderr
 
 html_theme = 'pydata_sphinx_theme'
 html_static_path = ['_static']
-html_extra_path = ['site/extra_output']
 html_title = "deepcell-types"

--- a/docs/site/tutorial.md
+++ b/docs/site/tutorial.md
@@ -235,7 +235,7 @@ mask_lyr.contour = 3  # Relatively thick borders for static viz
 # For static rendering - can safely be ignored if running notebook interactively
 from pathlib import Path
 
-screenshot_path = Path("extra_output/_generated")
+screenshot_path = Path("../_static/_generated")
 screenshot_path.mkdir(parents=True, exist_ok=True)
 nim.screenshot(
     path=screenshot_path / "napari_img_and_segmentation.png",
@@ -244,7 +244,7 @@ nim.screenshot(
 ```
 
 <center>
-  <img src="../_generated/napari_img_and_segmentation.png"
+  <img src="../_static/_generated/napari_img_and_segmentation.png"
        alt="Napari window of multiplexed image and computed segmentation mask"
        width=100%
   />
@@ -360,7 +360,7 @@ for k, l in labels_by_celltype.items():
 # For static rendering - can safely be ignored if running notebook interactively
 from pathlib import Path
 
-screenshot_path = Path("extra_output/_generated")
+screenshot_path = Path("../_static/_generated")
 screenshot_path.mkdir(parents=True, exist_ok=True)
 nim.screenshot(
     path=screenshot_path / "napari_celltype_layers.png",
@@ -370,7 +370,7 @@ nim.screenshot(
 
 
 <center>
-  <img src="../_generated/napari_celltype_layers.png"
+  <img src="../_static/_generated/napari_celltype_layers.png"
        alt="Napari window of multiplexed image with celltype predictions"
        width=100%
   />


### PR DESCRIPTION
Store napari screenshots generated as part of the doc build process (i.e. tutorial execution) within the `_static` directory.

This is a more "standard" location for sphinx and gets rid of the need for the `html_extra_path` config. It should also make things more recognizable for folks who have been exposed to sphinx.

Finally - there's still one necessary workaround: I had to add a dummy file to `_static` to ensure that the directory is always available, i.e. with a fresh clone or after a `git clean -xdf`. Without this, the `_static` dir would not be present and, due to complicated details of the order-of-operations of `sphinx-build`, the generated outputs would not be properly copied to _build. This workaround could be done away with if we had any other static files at all.