### PR TITLE
Convert to float internally

### DIFF
--- a/deepcell_types/dataset.py
+++ b/deepcell_types/dataset.py
@@ -26,7 +26,10 @@ class PatchDataset(IterableDataset):
     ):
         super(PatchDataset, self).__init__(**kwargs)
 
-        self.mask = mask
+        # Model requires image and mask in single precision
+        raw = raw.astype(np.float32)
+        self.mask = mask.astype(np.float32)
+
         self.dct_config = dct_config
         self.max_channels = dct_config.MAX_NUM_CHANNELS
         self.paddings = -1.0

--- a/docs/site/API-key.md
+++ b/docs/site/API-key.md
@@ -21,6 +21,7 @@ This line can be added to your shell configuration (e.g. ``.bashrc``, ``.zshrc``
 ``.bash_profile``, etc.) to automatically grant access to DeepCell models/data
 upon login.
 
+(download_models)=
 Models
 ------
 

--- a/docs/site/tutorial.md
+++ b/docs/site/tutorial.md
@@ -290,8 +290,8 @@ With the system all configured, we can now run the pipeline:
 :tags: [hide-output]
 
 cell_types = deepcell_types.predict(
-    img.astype(np.float32),
-    mask.astype(np.float32),
+    img,
+    mask,
     chnames,
     mpp,
     model_name=model,


### PR DESCRIPTION
The model requires both the image and mask have single-precision
dtype. The way things are currently structured, we require users
to make this conversion on their own. IMO this is something that
should be handled internally for the sake of UX.