### PR TITLE
Add explicit zarr version check to tutorial.

### DIFF
--- a/docs/site/tutorial.md
+++ b/docs/site/tutorial.md
@@ -45,11 +45,18 @@ The hubmap data mirror uses zarr format v3, thus requires `zarr>2` to be
 installed.
 ```
 
-### Exploring the archive
-
 ```{code-cell} ipython3
 import zarr
 
+if not zarr.__version__.startswith("3"):
+    raise EnvironmentError(
+        f"The tutorail requires `zarr>3`, version {zarr.__version__} found."
+    )
+```
+
+### Exploring the archive
+
+```{code-cell} ipython3
 z = zarr.open_group(
     store="s3://deepcelltypes-demo-datasets/hubmap.zarr",
     mode="r",

--- a/docs/site/tutorial.md
+++ b/docs/site/tutorial.md
@@ -50,7 +50,7 @@ import zarr
 
 if not zarr.__version__.startswith("3"):
     raise EnvironmentError(
-        f"The tutorail requires `zarr>3`, version {zarr.__version__} found."
+        f"The tutorial requires `zarr>3`, version {zarr.__version__} found."
     )
 ```
 


### PR DESCRIPTION
Closes #5 , at least to the best of our ability. There's not much we can do about the zarr 2/3 transition issues and I think we definitely want to stick with v3 for future compatibility. Adding this explicit check will at least notify folks when they have an incompatible environment for accessing the tutorial data.