### PR TITLE
docs: update citation to bioRxiv v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ No submodules are required.
 ```
 @article{deepcelltypes,
   title={Generalized cell phenotyping for spatial proteomics with language-informed vision models},
-  author={Wang, Xuefei and Dilip, Rohit and Bussi, Yuval and Brown, Caitlin and Pradhan, Elora and Jain, Yashvardhan and Yu, Kevin and Li, Shenyi and Abt, Martin and Borner, Katy and others},
+  author={Wang, Xuefei and Dilip, Rohit and Bussi, Yuval and Brown, Caitlin and Pradhan, Elora and Jain, Yashvardhan and Yu, Kevin and Li, Shenyi and Abt, Martin and Borner, Katy and Keren, Leeat and Yue, Yisong and Barnowski, Ross and Van Valen, David},
   journal={bioRxiv},
   pages={2026--07},
   year={2026},

--- a/README.md
+++ b/README.md
@@ -228,8 +228,9 @@ No submodules are required.
   title={Generalized cell phenotyping for spatial proteomics with language-informed vision models},
   author={Wang, Xuefei and Dilip, Rohit and Bussi, Yuval and Brown, Caitlin and Pradhan, Elora and Jain, Yashvardhan and Yu, Kevin and Li, Shenyi and Abt, Martin and Borner, Katy and others},
   journal={bioRxiv},
-  pages={2024--11},
-  year={2024},
-  publisher={Cold Spring Harbor Laboratory}
+  pages={2026--07},
+  year={2026},
+  publisher={Cold Spring Harbor Laboratory},
+  url={https://www.biorxiv.org/content/10.1101/2024.11.02.621624v4}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ No submodules are required.
 ```
 @article{deepcelltypes,
   title={Generalized cell phenotyping for spatial proteomics with language-informed vision models},
-  author={Wang, Xuefei and Dilip, Rohit and Bussi, Yuval and Brown, Caitlin and Pradhan, Elora and Jain, Yashvardhan and Yu, Kevin and Li, Shenyi and Abt, Martin and Borner, Katy and Keren, Leeat and Yue, Yisong and Barnowski, Ross and Van Valen, David},
+  author={Wang, Xuefei and Dilip, Rohit and Iqbal, Ahamed Raffey and Bussi, Yuval and Brown, Caitlin and Pradhan, Elora and Jain, Yashvardhan and Yu, Kevin and Li, Shenyi and Abt, Martin and Borner, Katy and Keren, Leeat and Yue, Yisong and Barnowski, Ross and Van Valen, David},
   journal={bioRxiv},
   pages={2026--07},
   year={2026},


### PR DESCRIPTION
## Summary
Updates the citation block in `README.md` to reference the latest bioRxiv version (v4, posted 2026-07-06).

- Add `url` field pointing to the v4 preprint page
- Bump `year` 2024 → 2026 and `pages` 2024--11 → 2026--07 to match the v4 posting date

The DOI (`10.1101/2024.11.02.621624`) is unchanged across versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnpBk4LMEG6MiUrEgt8khK