### PR TITLE
Sync: usability, packaging, correctness & test-coverage improvements since v0.1.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,7 +28,11 @@ htmlcov/
 # Local artifacts (datasets, model weights, inference outputs) — see .gitignore
 /data/
 /model/
+/models/
 /output/
+
+# Generated documentation
+docs/_build/
 
 # /deep-review outputs and local agent planning artifacts (not part of the package)
 /reviews/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# Keep the build context (and image layers) free of local-only files that
+# `pip install ".${DCT_EXTRAS}"` (see Dockerfile) never needs: it only reads
+# pyproject.toml, README.md, LICENSE, and the deepcell_types/ package tree.
+
+# Version control
+.git
+.gitignore
+
+# Local virtual environments / secrets
+.venv
+.env
+.env.*
+
+# Byte-compiled / packaging artifacts
+__pycache__/
+*.pyc
+*.egg-info/
+build/
+dist/
+
+# Test / lint / type-checker caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+
+# Local artifacts (datasets, model weights, inference outputs) — see .gitignore
+/data/
+/model/
+/output/
+
+# /deep-review outputs and local agent planning artifacts (not part of the package)
+/reviews/
+audit/
+docs/superpowers/
+
+# Per-project Claude Code settings (local-only, not for upstream)
+.claude/

--- a/README.md
+++ b/README.md
@@ -127,7 +127,11 @@ can also call directly if you already know the fix. Build one declaratively from
 bounded set of ops:
 
 ```python
+import torch
+
 from deepcell_types import predict, make_preprocessor
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
 
 config = [
     {"op": "clip_percentile", "p": 99.9},

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ labels = predict(raw, mask, channel_names, mpp,
                  model_name=model_path, device="cuda:0")
 ```
 
+No CUDA-capable GPU? Pass `device="cpu"` instead — inference works the same,
+just slower.
+
 For a complete example of the cell-type inference pipeline, check out
 the [tutorial](https://vanvalenlab.github.io/deepcell-types/site/tutorial.html).
 

--- a/README.md
+++ b/README.md
@@ -59,17 +59,21 @@ required**. The marker / cell-type registry ships inside the package as a
 automatically:
 
 ```python
+import torch
+
 from deepcell_types import predict
+
+# Pick a device: the default GPU if one is available, otherwise the CPU
+# (inference works the same on CPU, just slower). Use "cuda:1", "cuda:2",
+# etc. to target a specific GPU.
+device = "cuda" if torch.cuda.is_available() else "cpu"
 
 # raw: numpy (C, H, W); mask: 2D label image; channel_names: list[str]
 # Pass the path returned by download_model() straight through to predict();
 # predict() also accepts a filesystem path to a .pt file directly.
 labels = predict(raw, mask, channel_names, mpp,
-                 model_name=model_path, device="cuda:0")
+                 model_name=model_path, device=device)
 ```
-
-No CUDA-capable GPU? Pass `device="cpu"` instead — inference works the same,
-just slower.
 
 For a complete example of the cell-type inference pipeline, check out
 the [tutorial](https://vanvalenlab.github.io/deepcell-types/site/tutorial.html).
@@ -131,7 +135,7 @@ config = [
     {"op": "min_max_normalize"},                # model sees [0, 1]
 ]
 labels = predict(raw, mask, channel_names, mpp, model_name=...,
-                 device="cuda:0", preprocess=make_preprocessor(config))
+                 device=device, preprocess=make_preprocessor(config))
 ```
 
 The hook receives the resampled, in-vocabulary raw `(C, H, W)` array and the

--- a/deepcell_types/__init__.py
+++ b/deepcell_types/__init__.py
@@ -35,6 +35,8 @@ from .utils import download_model as download_model
 from .utils import download_training_data as download_training_data
 from .utils import list_baseline_names as list_baseline_names
 from .utils import list_model_versions as list_model_versions
+from .utils import list_supported_cell_types as list_supported_cell_types
+from .utils import list_supported_markers as list_supported_markers
 
 try:
     __version__ = version("deepcell-types")
@@ -55,6 +57,8 @@ __all__ = [
     "download_training_data",
     "list_model_versions",
     "list_baseline_names",
+    "list_supported_markers",
+    "list_supported_cell_types",
     "ABSTENTION_LABEL",
     "__version__",
 ]

--- a/deepcell_types/__init__.py
+++ b/deepcell_types/__init__.py
@@ -37,6 +37,7 @@ from .utils import list_baseline_names as list_baseline_names
 from .utils import list_model_versions as list_model_versions
 from .utils import list_supported_cell_types as list_supported_cell_types
 from .utils import list_supported_markers as list_supported_markers
+from .utils import resolve_supported_marker as resolve_supported_marker
 
 try:
     __version__ = version("deepcell-types")
@@ -59,6 +60,7 @@ __all__ = [
     "list_baseline_names",
     "list_supported_markers",
     "list_supported_cell_types",
+    "resolve_supported_marker",
     "ABSTENTION_LABEL",
     "__version__",
 ]

--- a/deepcell_types/abstention.py
+++ b/deepcell_types/abstention.py
@@ -25,7 +25,7 @@ Operating points:
 * ``k = 1.5`` (canonical Tukey): near-no-op (~0.23% abstained,
   +0.02pp macro).
 * ``k <= 0``: callers skip abstention. (Passing ``k = 0`` to
-  :func:`compute_iqr_fence` directly gives ``fence = Q1``, not a no-op.)
+  ``_compute_iqr_fence`` directly gives ``fence = Q1``, not a no-op.)
 
 :func:`apply_abstention` (this module) applies the same fence to a pandas
 DataFrame of DCT predictions, grouped by FOV — the batched form used by the
@@ -40,7 +40,7 @@ from typing import Optional, Sequence
 import numpy as np
 
 
-__all__ = ["ABSTENTION_LABEL", "compute_iqr_fence", "apply_abstention"]
+__all__ = ["ABSTENTION_LABEL", "apply_abstention"]
 
 ABSTENTION_LABEL = "Unknown"
 """Sentinel cell-type name used for cells flagged as abstained.
@@ -51,7 +51,7 @@ output for cells whose max-softmax falls below the IQR fence.
 """
 
 
-def compute_iqr_fence(max_softmax: np.ndarray, k: float) -> Optional[float]:
+def _compute_iqr_fence(max_softmax: np.ndarray, k: float) -> Optional[float]:
     """Compute the Tukey lower fence ``Q1 - k * IQR`` for a 1D array.
 
     Returns ``None`` when fewer than 4 values are supplied (the IQR is
@@ -100,7 +100,7 @@ def apply_abstention(
     the macro/weighted denominator.
 
     Per-group fences are computed independently. Groups with fewer than 4 cells
-    have no fence (no abstention fires for them — see :func:`compute_iqr_fence`).
+    have no fence (no abstention fires for them — see ``_compute_iqr_fence``).
     Groups whose max_softmax distribution is degenerate (all identical) yield
     fence == Q1, so ``vals >= fence`` is all True (no abstention fires).
     """
@@ -130,7 +130,7 @@ def apply_abstention(
     for _gkey, idx in grouped.items():
         if len(idx) < 4:
             continue
-        fence = compute_iqr_fence(max_p[idx], k)
+        fence = _compute_iqr_fence(max_p[idx], k)
         if fence is None:
             continue
         abstained[idx] = max_p[idx] < fence

--- a/deepcell_types/baselines/nimbus/run.py
+++ b/deepcell_types/baselines/nimbus/run.py
@@ -130,6 +130,42 @@ def load_fov_data(
     return raw, mask, channel_names, cell_info
 
 
+# Dataset-level failure-rate gate for the FOV-loading loop in main(). Mirrors
+# the ``failed_keys`` / fail-rate convention in
+# ``deepcell_types/training/dataset.py`` (cell-data cache build): baselines
+# must be scored at full coverage (see ``deepcell_types/abstention.py``), so a
+# silent drop of skipped/failed datasets must never be invisible.
+NIMBUS_DATASET_FAILURE_RATE_THRESHOLD = 0.01
+
+
+def check_dataset_coverage(
+    skipped_keys: List[str],
+    total_keys: int,
+    threshold: float = NIMBUS_DATASET_FAILURE_RATE_THRESHOLD,
+) -> None:
+    """Report and gate on dataset-level coverage loss.
+
+    Always prints an aggregate "Skipped N of M datasets" line so a coverage
+    drop is never silent, then raises ``RuntimeError`` if the failure rate
+    exceeds ``threshold`` (default 1%, matching
+    ``training/dataset.py``'s cache-build gate).
+    """
+    n_skipped = len(skipped_keys)
+    print(f"Skipped {n_skipped} of {total_keys} datasets")
+    if n_skipped == 0:
+        return
+    fail_rate = n_skipped / max(1, total_keys)
+    if fail_rate > threshold:
+        raise RuntimeError(
+            f"Nimbus baseline dropped {n_skipped} of {total_keys} datasets "
+            f"({fail_rate:.1%}, above the {threshold:.0%} safety threshold). "
+            "Baselines must be scored at full coverage (see abstention.py) "
+            "so this would bias the baseline comparison. Inspect the warnings "
+            f"above and either fix the archive or relax the threshold "
+            f"deliberately. Skipped keys (first 10): {skipped_keys[:10]}"
+        )
+
+
 def compute_marker_positivity_metrics(
     predictions: pd.DataFrame,
     ground_truth: Dict[str, pd.DataFrame],
@@ -387,6 +423,7 @@ def main(
     # Process each dataset
     all_predictions = []
     fov_count = 0
+    skipped_dataset_keys: List[str] = []
 
     from scipy.ndimage import mean as ndimage_mean
     import cv2
@@ -474,6 +511,7 @@ def main(
         # Check if preprocessed data exists
         if "preprocessed" not in ds:
             print(f"Warning: No preprocessed data for {dataset_key}, skipping")
+            skipped_dataset_keys.append(dataset_key)
             continue
 
         try:
@@ -481,8 +519,14 @@ def main(
             _, mask, channel_names, cell_info = load_fov_data(
                 zf, dataset_key, load_raw=False
             )
-        except Exception as e:
+        except (KeyError, ValueError, AttributeError, TypeError, OSError) as e:
+            # Narrowed from a bare ``except Exception`` (mirrors the expected-error
+            # set in training/dataset.py's cache build): missing zarr paths
+            # (KeyError/OSError), the explicit "No cell annotations found"
+            # ValueError, and malformed attrs (AttributeError/TypeError).
+            # Schema/logic bugs outside this set should crash loudly.
             print(f"Error loading {dataset_key}: {e}")
+            skipped_dataset_keys.append(dataset_key)
             continue
 
         # Prepare binary mask once per FOV (with boundary erosion, matching original Nimbus)
@@ -592,6 +636,12 @@ def main(
         if max_fovs and fov_count >= max_fovs:
             print(f"\nReached max_fovs limit ({max_fovs})")
             break
+
+    # Report and gate on dataset-level coverage loss before metrics are
+    # finalized (baselines must be scored at full coverage). Denominator is
+    # datasets actually attempted (succeeded + skipped), not the full
+    # dataset_keys list, since --max_fovs can end the loop early.
+    check_dataset_coverage(skipped_dataset_keys, fov_count + len(skipped_dataset_keys))
 
     # Combine all predictions
     if len(all_predictions) == 0:

--- a/deepcell_types/dataset.py
+++ b/deepcell_types/dataset.py
@@ -31,6 +31,11 @@ class PatchDataset(IterableDataset):
             raise ValueError("raw must have shape (C, H, W).")
         if mask.ndim != 2:
             raise ValueError("mask must be a 2D label image.")
+        if raw.shape[1:] != mask.shape:
+            raise ValueError(
+                f"raw spatial shape {raw.shape[1:]} does not match mask shape "
+                f"{mask.shape}."
+            )
         if raw.shape[0] != len(channel_names):
             raise ValueError(
                 f"raw has {raw.shape[0]} channels, but {len(channel_names)} "

--- a/deepcell_types/predict.py
+++ b/deepcell_types/predict.py
@@ -6,7 +6,7 @@ from typing import List
 import numpy as np
 from tqdm import tqdm
 
-from .abstention import ABSTENTION_LABEL, compute_iqr_fence
+from .abstention import ABSTENTION_LABEL, _compute_iqr_fence
 from .config import DCTConfig
 
 __all__ = ["predict", "PredictionResult"]
@@ -501,7 +501,7 @@ def predict(
 
     # A custom model / preprocess hook can emit non-finite logits; softmax then
     # yields NaN and np.argmax silently labels the cell class 0. Fail loudly
-    # rather than return confident garbage. (compute_iqr_fence drops non-finite
+    # rather than return confident garbage. (_compute_iqr_fence drops non-finite
     # values, so abstention would not catch this on its own.)
     if full_probs.size and not np.isfinite(full_probs).all():
         raise ValueError(
@@ -511,12 +511,12 @@ def predict(
 
     # IQR-fence abstention on the FOV's max-softmax distribution. Abstention is
     # bucketed per FOV, and this API processes a single FOV, so the whole input
-    # is one bucket and no grouping column is needed — `compute_iqr_fence`
+    # is one bucket and no grouping column is needed — `_compute_iqr_fence`
     # returns None when n_cells < 4, in which case no cells are abstained.
     abstained = np.zeros(len(cell_types_raw), dtype=bool)
     cell_types = list(cell_types_raw)
     if ct_abstention_k is not None and ct_abstention_k > 0 and len(_top_probs) >= 4:
-        fence = compute_iqr_fence(_top_probs, float(ct_abstention_k))
+        fence = _compute_iqr_fence(_top_probs, float(ct_abstention_k))
         if fence is not None:
             abstained = _top_probs < fence
             cell_types = [

--- a/deepcell_types/predict.py
+++ b/deepcell_types/predict.py
@@ -33,8 +33,9 @@ def validate_checkpoint_vocabulary(checkpoint, ct2idx, marker2idx):
 
     - The checkpoint must bundle its own ``ct2idx``, and it must match ``ct2idx``
       (name -> index mapping, order-independent).
-    - If the checkpoint bundles ``canonical_channels`` it must match the marker
-      ordering (compared by numeric marker index, not dict insertion order).
+    - The checkpoint must also bundle its own ``canonical_channels``, and it
+      must match the marker ordering (compared by numeric marker index, not
+      dict insertion order).
 
     Raises ``ValueError`` on any mismatch.
     """
@@ -56,8 +57,16 @@ def validate_checkpoint_vocabulary(checkpoint, ct2idx, marker2idx):
     ckpt_channels = (
         checkpoint.get("canonical_channels") if isinstance(checkpoint, dict) else None
     )
+    if ckpt_channels is None:
+        raise ValueError(
+            "Checkpoint does not bundle canonical_channels, so the marker "
+            "ordering cannot be verified and a permuted marker vocabulary "
+            "would silently mislabel every cell. Use a checkpoint that "
+            "bundles its own canonical_channels (scripts/train.py and "
+            "retrain_head.py record it)."
+        )
     marker_order = _names_ordered_by_index(marker2idx)
-    if ckpt_channels is not None and list(ckpt_channels) != marker_order:
+    if list(ckpt_channels) != marker_order:
         raise ValueError(
             "Checkpoint marker ordering (canonical_channels) does not match the "
             "inference vocabulary's marker2idx ordering."

--- a/deepcell_types/training/splits.py
+++ b/deepcell_types/training/splits.py
@@ -13,6 +13,7 @@ functions only take a ``dataset`` instance as a parameter (no import of
 import json
 import logging
 import random
+import re
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -131,7 +132,59 @@ def _build_fov_strata(dataset, fov_to_indices, stratify_by):
     return fov_to_stratum
 
 
-def create_fov_splits(dataset, train_ratio=0.8, seed=42, stratify_by=()):
+def parse_patient_id(fov_key):
+    """Best-effort patient/donor id parsed from a ``fov_key`` naming convention.
+
+    There is no structured patient/donor metadata in the archive (only
+    ``tissue``/``modality`` zarr attrs, see ``_build_fov_strata``) — patient
+    identity, where recoverable at all, is embedded in the dataset/FOV name
+    string itself. This currently only recognizes the known
+    ``...Patient<N>...`` convention used by e.g. the McCaffrey TB MIBI
+    dataset (``mccaffrey_tb_mibi_lung_Patient3-2`` -> patient id
+    ``"mccaffrey_tb_mibi_lung_Patient3"``).
+
+    The returned id is anchored to everything up to and including
+    ``Patient<N>`` (not just the bare number), so that two unrelated source
+    datasets that both happen to have a "Patient3" are never merged into the
+    same group.
+
+    Args:
+        fov_key: (dataset_name, fov_name) tuple, as used elsewhere in this
+            module.
+
+    Returns:
+        The parsed patient id string, or None if neither field matches the
+        known convention (caller should fall back to per-FOV handling).
+    """
+    for candidate in fov_key:
+        match = re.search(r"^.*?Patient\d+", str(candidate))
+        if match:
+            return match.group(0)
+    return None
+
+
+def _group_fov_keys_by_patient(fov_keys):
+    """Group ``fov_keys`` sharing a ``parse_patient_id`` result into units.
+
+    Returns a list of "units", where each unit is a list of one or more
+    fov_keys that must be assigned to the same split (train xor val) as a
+    whole. FOVs with no parseable patient id become their own singleton
+    unit — identical to the ungrouped, per-FOV behavior.
+    """
+    patient_to_unit = defaultdict(list)
+    singleton_units = []
+    for fov_key in fov_keys:
+        patient_id = parse_patient_id(fov_key)
+        if patient_id is None:
+            singleton_units.append([fov_key])
+        else:
+            patient_to_unit[patient_id].append(fov_key)
+    return list(patient_to_unit.values()) + singleton_units
+
+
+def create_fov_splits(
+    dataset, train_ratio=0.8, seed=42, stratify_by=(), group_by_patient=False
+):
     """Split dataset by FOV (no spatial leakage).
 
     Groups cells by FOV, then assigns entire FOVs to train or val.
@@ -149,6 +202,16 @@ def create_fov_splits(dataset, train_ratio=0.8, seed=42, stratify_by=()):
         seed: Random seed
         stratify_by: Tuple of stratification keys, e.g. ("modality", "tissue").
             Empty tuple disables stratification (legacy global shuffle).
+        group_by_patient: If True, FOVs whose key matches the known
+            ``...Patient<N>...`` naming convention (see ``parse_patient_id``)
+            are grouped so every FOV from the same patient lands entirely in
+            train or entirely in val, instead of being shuffled
+            independently — prevents patient-level leakage across the split.
+            FOVs with no parseable patient id keep the per-FOV behavior.
+            Only applies within the ``stratify_by`` per-stratum split (a
+            no-op when ``stratify_by`` is empty). Default False: existing
+            callers and split files are unaffected unless this is
+            explicitly requested.
 
     Returns:
         train_indices: List of integer indices into dataset
@@ -184,17 +247,38 @@ def create_fov_splits(dataset, train_ratio=0.8, seed=42, stratify_by=()):
         single_fov_strata = []
         for stratum in sorted(by_stratum.keys()):
             keys = list(by_stratum[stratum])
-            rng.shuffle(keys)
-            if len(keys) == 1:
+            # Collapse FOVs sharing a parsed patient id into single "units"
+            # that are assigned to a split as a whole (see
+            # _group_fov_keys_by_patient). When group_by_patient=False every
+            # unit is a singleton [fov_key] — identical to the old,
+            # ungrouped per-FOV list — so behavior is unchanged by default.
+            units = (
+                _group_fov_keys_by_patient(keys)
+                if group_by_patient
+                else [[fk] for fk in keys]
+            )
+            rng.shuffle(units)
+            if len(units) == 1:
+                # Whole stratum is one unsplittable unit — either a single
+                # FOV, or (with group_by_patient) a single patient group
+                # spanning every remaining FOV in this stratum. Can't
+                # evaluate a held-out portion either way, so force to train
+                # (same rule as the pre-existing single-FOV case).
                 single_fov_strata.append(stratum)
-                train_indices.extend(fov_to_indices[keys[0]])
+                for fk in units[0]:
+                    train_indices.extend(fov_to_indices[fk])
                 continue
-            # Round to nearest, clamp so neither side is empty
-            n_train = max(1, min(len(keys) - 1, int(round(len(keys) * train_ratio))))
-            for fk in keys[:n_train]:
-                train_indices.extend(fov_to_indices[fk])
-            for fk in keys[n_train:]:
-                val_indices.extend(fov_to_indices[fk])
+            # Round to nearest, clamp so neither side is empty. Ratio is
+            # computed over units, not raw FOV counts: with group_by_patient
+            # this trades exact train_ratio adherence for never splitting a
+            # patient across train/val.
+            n_train = max(1, min(len(units) - 1, int(round(len(units) * train_ratio))))
+            for unit in units[:n_train]:
+                for fk in unit:
+                    train_indices.extend(fov_to_indices[fk])
+            for unit in units[n_train:]:
+                for fk in unit:
+                    val_indices.extend(fov_to_indices[fk])
         if single_fov_strata:
             logger.info(
                 "stratified split: %d single-FOV strata forced to train (cannot eval): %s",
@@ -251,7 +335,14 @@ def _format_fov_examples(fov_keys, limit=5):
     return ", ".join(f"{ds}/{fov}" for ds, fov in examples) + suffix
 
 
-def save_fov_splits(dataset, split_file, train_ratio=0.8, seed=42, stratify_by=()):
+def save_fov_splits(
+    dataset,
+    split_file,
+    train_ratio=0.8,
+    seed=42,
+    stratify_by=(),
+    group_by_patient=False,
+):
     """Generate FOV splits and save to a JSON file for reproducibility.
 
     Delegates to ``create_fov_splits`` for the actual partitioning logic
@@ -266,6 +357,8 @@ def save_fov_splits(dataset, split_file, train_ratio=0.8, seed=42, stratify_by=(
         stratify_by: Tuple of stratification keys, e.g. ``("modality", "tissue")``.
             Empty tuple disables stratification (legacy global shuffle, used by
             v9 splits for benchmark continuity).
+        group_by_patient: See ``create_fov_splits``. Default False (no change
+            to existing split files unless explicitly requested).
 
     Returns:
         train_indices, val_indices (same as ``create_fov_splits``).
@@ -275,6 +368,7 @@ def save_fov_splits(dataset, split_file, train_ratio=0.8, seed=42, stratify_by=(
         train_ratio=train_ratio,
         seed=seed,
         stratify_by=stratify_by,
+        group_by_patient=group_by_patient,
     )
 
     # Reconstruct (dataset_name -> [fov_names]) groupings from the per-cell
@@ -299,7 +393,10 @@ def save_fov_splits(dataset, split_file, train_ratio=0.8, seed=42, stratify_by=(
         val_fov_keys.add(fov_key)
         val_split.setdefault(fov_key[0], []).append(fov_key[1])
 
-    # Re-derive single-FOV stratum count for metadata transparency.
+    # Re-derive single-unit stratum count for metadata transparency. A "unit"
+    # is a single FOV, or (group_by_patient=True) a whole patient group — see
+    # create_fov_splits. Mirrors that function's own single-unit forced-to-
+    # train rule so this count stays accurate whether or not grouping is on.
     num_single_fov_strata = 0
     if stratify_by:
         fov_to_indices = defaultdict(list)
@@ -312,13 +409,21 @@ def save_fov_splits(dataset, split_file, train_ratio=0.8, seed=42, stratify_by=(
             if fov_key in forced:
                 continue
             by_stratum[fov_to_stratum[fov_key]].append(fov_key)
-        num_single_fov_strata = sum(1 for v in by_stratum.values() if len(v) == 1)
+        for stratum_keys in by_stratum.values():
+            n_units = (
+                len(_group_fov_keys_by_patient(stratum_keys))
+                if group_by_patient
+                else len(stratum_keys)
+            )
+            if n_units == 1:
+                num_single_fov_strata += 1
 
     split_data = {
         "metadata": {
             "seed": seed,
             "train_ratio": train_ratio,
             "stratify_by": list(stratify_by),
+            "group_by_patient": bool(group_by_patient),
             "num_train_fovs": sum(len(v) for v in train_split.values()),
             "num_val_fovs": sum(len(v) for v in val_split.values()),
             "num_datasets": len(set(list(train_split) + list(val_split))),

--- a/deepcell_types/training/utils.py
+++ b/deepcell_types/training/utils.py
@@ -88,6 +88,55 @@ def load_matching_state_dict(model, state_dict):
     return loaded
 
 
+def resume_onecycle_schedule(scheduler, resume_state, *, logger=None):
+    """Restore a ``OneCycleLR``'s position from a checkpoint on ``--resume_path``.
+
+    ``scheduler`` must already be constructed with the CURRENT run's
+    ``total_steps`` (i.e. derived from the current ``--epochs``). ``resume_state``
+    is the raw ``scheduler.state_dict()`` saved in the checkpoint being resumed.
+
+    Trap this guards against: ``torch.optim.lr_scheduler.LRScheduler.load_state_dict``
+    is just ``self.__dict__.update(state_dict)``. Calling
+    ``scheduler.load_state_dict(resume_state)`` unconditionally therefore
+    overwrites the freshly-built scheduler's ``total_steps`` (and the derived
+    ``_schedule_phases``) with the CHECKPOINTED run's values — so resuming with
+    a larger ``--epochs`` than the original run silently keeps training on the
+    old, shorter schedule instead of the new, longer one.
+
+    If the checkpoint's ``total_steps`` matches ``scheduler.total_steps`` (i.e.
+    ``--epochs`` didn't change), the checkpoint is loaded verbatim, matching
+    prior behavior exactly. Otherwise the freshly-built scheduler (already at
+    the new total_steps) is kept and fast-forwarded by replaying ``.step()``
+    the same number of times the checkpointed run had already taken, so the LR
+    position is preserved but the remaining schedule reflects the new
+    total_steps.
+    """
+    log = logger or globals()["logger"]
+    resumed_total_steps = resume_state.get("total_steps")
+    resumed_step_count = resume_state.get("last_epoch", 0)
+    if resumed_total_steps == scheduler.total_steps:
+        scheduler.load_state_dict(resume_state)
+        return
+    log.warning(
+        "Resumed OneCycleLR total_steps changed (%s -> %s, likely from a "
+        "changed --epochs); rebuilding the schedule at the new length and "
+        "fast-forwarding to step %s instead of loading the checkpoint's "
+        "schedule verbatim.",
+        resumed_total_steps,
+        scheduler.total_steps,
+        resumed_step_count,
+    )
+    if resumed_step_count > scheduler.total_steps:
+        raise ValueError(
+            f"Checkpoint already completed {resumed_step_count} scheduler "
+            f"steps, which exceeds the new total_steps={scheduler.total_steps} "
+            "implied by the current --epochs. Increase --epochs so the new "
+            "schedule covers at least the already-completed steps."
+        )
+    for _ in range(resumed_step_count):
+        scheduler.step()
+
+
 def _feature_cache_metadata(
     zarr_dir: str,
     dct_config,

--- a/deepcell_types/utils/__init__.py
+++ b/deepcell_types/utils/__init__.py
@@ -46,41 +46,46 @@ _model_registry = {
 
 # Baseline-model checkpoints. Values are lists of ``(asset_filename, md5)``.
 # Single-file baselines have a one-element list; ``maps`` and ``xgboost``
-# additionally ship a companion file required at inference.
+# additionally ship a companion file required at inference. The md5s track the
+# 2026-06-30 DCT-sampler retrains -- the release-of-record that produced the
+# published baseline prediction CSVs and headline numbers.
+#
+# Nimbus is intentionally absent: it is inference-only with pretrained weights
+# produced and distributed upstream (angelolab/Nimbus-Inference), which this
+# project does not redistribute. ``download_baseline_checkpoint("nimbus")``
+# raises with a pointer to the official source instead (see below).
 _baseline_registry = {
     "cellsighter": [
         (
             "deepcell-types_baseline-cellsighter.pth",
-            "d06f8aeef485e7c40590cc35da80944b",
+            "c5a105fb044ad82c82817a32aabbae7c",
         ),
     ],
     "maps": [
         (
             "deepcell-types_baseline-maps.pth",
-            "d2d1930d438c014c226202b8b7fa4a65",
+            "1ad5e30ceaccfdb91050b663099258fb",
         ),
         (
             "deepcell-types_baseline-maps_stats.npz",
-            "e3a54e5a64d5376231abf1022b001a41",
-        ),
-    ],
-    "nimbus": [
-        (
-            "deepcell-types_baseline-nimbus.pt",
-            "47916fbebc3a58d5bee96a9289d157aa",
+            "1f462d0c8bf531af73026d415d52728d",
         ),
     ],
     "xgboost": [
         (
             "deepcell-types_baseline-xgboost.json",
-            "00d110cc0e9f429b3014845f05a13060",
+            "9e51cf1af8c6c43b00871a821fde0f57",
         ),
         (
             "deepcell-types_baseline-xgboost.remap.json",
-            "0d94609aa7127672111797df920920b7",
+            "fba1b0e705e5f7747eb2f9cae30815ba",
         ),
     ],
 }
+
+# Nimbus pretrained weights are distributed upstream (via the
+# ``nimbus-inference`` library / Hugging Face Hub), not re-hosted here.
+_NIMBUS_UPSTREAM_URL = "https://github.com/angelolab/Nimbus-Inference"
 
 
 def download_model(*, version=None):
@@ -139,8 +144,10 @@ def download_baseline_checkpoint(name):
     Parameters
     ----------
     name : str
-        Baseline identifier. One of ``cellsighter``, ``maps``,
-        ``nimbus``, or ``xgboost``.
+        Baseline identifier. One of ``cellsighter``, ``maps``, or
+        ``xgboost``. ``nimbus`` is not served here (its weights are
+        distributed upstream); requesting it raises with a pointer to the
+        official source.
 
     Returns
     -------
@@ -153,6 +160,14 @@ def download_baseline_checkpoint(name):
     """
     from ._auth import fetch_data
 
+    if name == "nimbus":
+        raise ValueError(
+            "The Nimbus baseline is inference-only and its pretrained weights "
+            "are distributed upstream, not re-hosted by this project. Install "
+            "the official library (`pip install -e '.[baseline-nimbus]'`), which "
+            "downloads the weights automatically; see "
+            f"{_NIMBUS_UPSTREAM_URL}."
+        )
     if name not in _baseline_registry:
         raise ValueError(
             f"Unknown baseline {name!r}. Known baselines: {sorted(_baseline_registry)}."

--- a/deepcell_types/utils/__init__.py
+++ b/deepcell_types/utils/__init__.py
@@ -16,6 +16,8 @@ __all__ = [
     "download_training_data",
     "list_model_versions",
     "list_baseline_names",
+    "list_supported_markers",
+    "list_supported_cell_types",
 ]
 
 _latest = "2026-06-15"
@@ -161,6 +163,55 @@ def list_baseline_names():
         ``list``-returning counterpart to :func:`list_model_versions`).
     """
     return sorted(_baseline_registry)
+
+
+def list_supported_markers(*, zarr_path=None):
+    """Return the marker/channel names the packaged registry recognizes, sorted.
+
+    Lets a user pre-flight-check whether their marker panel overlaps the
+    model's registry before downloading a checkpoint or running inference.
+    Reads the packaged ``vocab.json`` snapshot via :class:`.DCTConfig`
+    (no archive or checkpoint required); pass ``zarr_path`` to inspect an
+    archive's registry instead.
+
+    Parameters
+    ----------
+    zarr_path : str or Path, optional
+        Forwarded to :class:`.DCTConfig`. If ``None`` (default), resolves the
+        ``DEEPCELL_TYPES_ZARR_PATH`` environment variable and falls back to
+        the packaged ``vocab.json``.
+
+    Returns
+    -------
+    list of str
+        Recognized marker names, sorted.
+    """
+    from ..config import DCTConfig
+
+    return sorted(DCTConfig(zarr_path=zarr_path).marker2idx)
+
+
+def list_supported_cell_types(*, zarr_path=None):
+    """Return the cell-type names the packaged registry recognizes, sorted.
+
+    The ``list``-returning counterpart to :func:`list_supported_markers`; see
+    its docstring for the pre-flight-check motivation.
+
+    Parameters
+    ----------
+    zarr_path : str or Path, optional
+        Forwarded to :class:`.DCTConfig`. If ``None`` (default), resolves the
+        ``DEEPCELL_TYPES_ZARR_PATH`` environment variable and falls back to
+        the packaged ``vocab.json``.
+
+    Returns
+    -------
+    list of str
+        Recognized cell-type names, sorted.
+    """
+    from ..config import DCTConfig
+
+    return sorted(DCTConfig(zarr_path=zarr_path).ct2idx)
 
 
 _training_data_asset_key = "data/deepcell-types/public_data_v1.1.zip"

--- a/deepcell_types/utils/__init__.py
+++ b/deepcell_types/utils/__init__.py
@@ -21,14 +21,26 @@ __all__ = [
 _latest = "2026-06-15"
 
 # Main model checkpoints. Values are ``(asset_filename, md5)``.
-# The headline release is the two-stage residual-MLP model
-# (``2026-06-15``): a sampler-trained backbone, frozen, with a residual-MLP
-# cell-type head retrained on the natural class distribution. It loads via
-# stock ``predict.py`` (the resMLP head is auto-detected).
+# Two released residual-MLP checkpoints share the current vocabulary (51 cell
+# types, 278 markers) and load via stock ``predict.py`` (the resMLP head is
+# auto-detected):
+#   - ``2026-06-15`` (default): the from-scratch resMLP (paper Fig-3c headline).
+#   - ``2026-06-23``: the pretrain -> finetune (SSL) resMLP arm.
+#
+# Each md5 tracks the vocab-bundled asset (carries ``ct2idx`` +
+# ``canonical_channels`` so ``validate_checkpoint_vocabulary`` can verify
+# ordering). The original un-bundled assets predated the guard and raised
+# ``ValueError: ... does not bundle a ct2idx`` on every ``predict()`` call;
+# they were re-packaged with ``scripts/repackage_release_checkpoint.py``. Each
+# bundled asset must be uploaded at its filename below before its md5 is served.
 _model_registry = {
     "2026-06-15": (
         "deepcell-types_2026-06-15_resmlp.pt",
-        "704616a1cfeb6f4718ffdb8d7ea64d65",
+        "b819a7e0b177ad5330394eab3c6c7ad8",
+    ),
+    "2026-06-23": (
+        "deepcell-types_2026-06-23_resmlp_ptft.pt",
+        "402e94c103c5e489a57433cd107009d3",
     ),
 }
 

--- a/deepcell_types/utils/__init__.py
+++ b/deepcell_types/utils/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     "list_baseline_names",
     "list_supported_markers",
     "list_supported_cell_types",
+    "resolve_supported_marker",
 ]
 
 _latest = "2026-06-15"
@@ -166,10 +167,12 @@ def list_baseline_names():
 
 
 def list_supported_markers(*, zarr_path=None):
-    """Return the marker/channel names the packaged registry recognizes, sorted.
+    """Return the canonical marker names in the active registry, sorted.
 
     Lets a user pre-flight-check whether their marker panel overlaps the
     model's registry before downloading a checkpoint or running inference.
+    Use :func:`resolve_supported_marker` to check acquisition names that may
+    be aliases or differ in capitalization.
     Reads the packaged ``vocab.json`` snapshot via :class:`.DCTConfig`
     (no archive or checkpoint required); pass ``zarr_path`` to inspect an
     archive's registry instead.
@@ -189,6 +192,31 @@ def list_supported_markers(*, zarr_path=None):
     from ..config import DCTConfig
 
     return sorted(DCTConfig(zarr_path=zarr_path).marker2idx)
+
+
+def resolve_supported_marker(marker, *, zarr_path=None):
+    """Resolve a marker name or alias to its canonical registry name.
+
+    Resolution matches inference behavior, including configured aliases and
+    case-insensitive names.
+
+    Parameters
+    ----------
+    marker : str
+        Marker/channel name to resolve.
+    zarr_path : str or Path, optional
+        Forwarded to :class:`.DCTConfig`. If ``None`` (default), resolves the
+        ``DEEPCELL_TYPES_ZARR_PATH`` environment variable and falls back to
+        the packaged ``vocab.json``.
+
+    Returns
+    -------
+    str or None
+        Canonical marker name, or ``None`` when the marker is unsupported.
+    """
+    from ..config import DCTConfig
+
+    return DCTConfig(zarr_path=zarr_path).resolve_channel_name(marker)
 
 
 def list_supported_cell_types(*, zarr_path=None):

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,14 +117,17 @@ and select `Open with -> Jupytext notebook`.
    `attrs.all_standardized_channels`. Either way, markers not found in the
    active registry are ignored at inference time.
 
-   To check whether your marker panel overlaps the registry before
-   downloading a checkpoint, call `list_supported_markers()` (and
-   `list_supported_cell_types()` for the recognized cell-type labels):
+   To inspect the canonical marker registry before downloading a checkpoint,
+   call `list_supported_markers()` (and `list_supported_cell_types()` for the
+   recognized cell-type labels). To check a panel name using the same alias
+   and capitalization handling as inference, call
+   `resolve_supported_marker()`:
 
    ```python
    import deepcell_types
 
    deepcell_types.list_supported_markers()
+   deepcell_types.resolve_supported_marker("Pan-Cytokeratin")  # "PanCK"
    ```
 
    There are two ways to add support for additional channels:

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,6 +116,17 @@ and select `Open with -> Jupytext notebook`.
    recognized channels are whatever the selected archive exposes in its root
    `attrs.all_standardized_channels`. Either way, markers not found in the
    active registry are ignored at inference time.
+
+   To check whether your marker panel overlaps the registry before
+   downloading a checkpoint, call `list_supported_markers()` (and
+   `list_supported_cell_types()` for the recognized cell-type labels):
+
+   ```python
+   import deepcell_types
+
+   deepcell_types.list_supported_markers()
+   ```
+
    There are two ways to add support for additional channels:
 
    - To add a new alias for a marker name that is currently supported, add the

--- a/docs/site/API-key.md
+++ b/docs/site/API-key.md
@@ -47,9 +47,14 @@ To fetch a baseline checkpoint instead of the main DeepCellTypes model:
 ```python
 from deepcell_types.utils import download_baseline_checkpoint
 
-# One of: "cellsighter", "maps", "nimbus", "xgboost"
+# One of: "cellsighter", "maps", "xgboost"
 download_baseline_checkpoint("maps")
 ```
+
+The Nimbus baseline is not served here: its pretrained weights are
+distributed upstream, so install it with `pip install -e ".[baseline-nimbus]"`
+(which fetches the weights automatically) rather than
+`download_baseline_checkpoint`.
 
 Training Data
 -------------

--- a/docs/site/reference.rst
+++ b/docs/site/reference.rst
@@ -42,3 +42,5 @@ Utilities
    download_training_data
    list_model_versions
    list_baseline_names
+   list_supported_markers
+   list_supported_cell_types

--- a/docs/site/reference.rst
+++ b/docs/site/reference.rst
@@ -44,3 +44,4 @@ Utilities
    list_baseline_names
    list_supported_markers
    list_supported_cell_types
+   resolve_supported_marker

--- a/docs/site/reference.rst
+++ b/docs/site/reference.rst
@@ -26,7 +26,6 @@ Abstention
 .. autosummary::
    :toctree: _generated/
 
-   compute_iqr_fence
    ABSTENTION_LABEL
 
 Utilities

--- a/docs/site/tutorial.md
+++ b/docs/site/tutorial.md
@@ -294,8 +294,12 @@ model = download_model(version="2026-06-15")
 ```{code-cell} ipython3
 # System-specific configuration
 
-# NOTE: if you do not have a cuda-capable GPU, try "cpu"
-device = "cuda:0"
+# Pick a device: the default GPU if one is available, otherwise the CPU
+# (inference works the same on CPU, just slower). Use "cuda:1", "cuda:2",
+# etc. to target a specific GPU.
+import torch
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
 # NOTE: For machines with many cores & large RAM (e.g. GPU nodes), consider
 # increasing for better performance.
 num_data_loader_threads = 1

--- a/scripts/generate_splits.py
+++ b/scripts/generate_splits.py
@@ -28,6 +28,11 @@ Usage (to reproduce stage 1 from a local archive):
 The default stratifies by (modality, tissue). Single-FOV strata are
 forced to train (cannot evaluate held-out FOVs from a one-FOV bucket).
 Empty `--stratify_by ""` reproduces the older global random shuffle.
+
+Pass `--group-by-patient` to additionally keep every FOV from the same
+patient (parsed from the known "...Patient<N>..." naming convention) on the
+same side of the split — off by default, so existing committed split files
+are reproduced unchanged unless this is explicitly requested.
 """
 
 import os
@@ -67,6 +72,18 @@ DATA_DIR = Path(
         "(legacy global shuffle, used by v9 splits). Supported keys: modality, tissue."
     ),
 )
+@click.option(
+    "--group-by-patient",
+    is_flag=True,
+    default=False,
+    help=(
+        "Group FOVs sharing a parsed patient id (the known '...Patient<N>...' "
+        "naming convention, e.g. the McCaffrey TB MIBI dataset) so a single "
+        "patient's FOVs never straddle train/val. FOVs with no parseable "
+        "patient id keep the existing per-FOV behavior. Default off, so "
+        "existing split files are reproduced unchanged unless this is passed."
+    ),
+)
 def main(
     zarr_dir,
     output,
@@ -75,6 +92,7 @@ def main(
     skip_datasets,
     keep_datasets,
     stratify_by,
+    group_by_patient,
 ):
     """Generate a canonical FOV split file."""
     dct_config = TissueNetConfig(zarr_dir)
@@ -96,6 +114,7 @@ def main(
         train_ratio=train_ratio,
         seed=seed,
         stratify_by=stratify_keys,
+        group_by_patient=group_by_patient,
     )
 
     print(f"Total samples: {len(dataset)}")

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -269,25 +269,7 @@ def main(
         ct_head_depth=ct_head_params["ct_head_depth"],
     )
 
-    if isinstance(checkpoint, dict) and "model" in checkpoint:
-        model.load_state_dict(checkpoint["model"])
-    else:
-        # Legacy format: plain state_dict — detect old Linear MP head
-        if (
-            "marker_pos_head.weight" in checkpoint
-            and "marker_pos_head.film_scale.weight" not in checkpoint
-        ):
-            model = create_model(
-                dct_config,
-                marker_embeddings,
-                d_model=d_model,
-                resnet_base_channels=resnet_channels,
-                use_conditioned_mp_head=False,
-                ct_head_width=ct_head_params["ct_head_width"],
-                ct_head_depth=ct_head_params["ct_head_depth"],
-            ).to(device)
-        model.load_state_dict(checkpoint)
-        print("Legacy checkpoint")
+    model.load_state_dict(checkpoint["model"])
 
     model.to(device)
     summary(model, col_names=["trainable"])

--- a/scripts/pretrain.py
+++ b/scripts/pretrain.py
@@ -34,6 +34,7 @@ from deepcell_types.training.utils import (
     BatchData,
     seed_everything,
     load_matching_state_dict,
+    resume_onecycle_schedule,
 )
 
 logger = logging.getLogger(__name__)
@@ -261,7 +262,13 @@ def main(
             if "recon_head" in resume_ckpt:
                 recon_head.load_state_dict(resume_ckpt["recon_head"])
             optimizer.load_state_dict(resume_ckpt["optimizer"])
-            scheduler.load_state_dict(resume_ckpt["scheduler"])
+            # See resume_onecycle_schedule() docstring: a naive
+            # scheduler.load_state_dict() here would silently overwrite
+            # total_steps with the checkpointed run's value, discarding an
+            # increased --epochs.
+            resume_onecycle_schedule(
+                scheduler, resume_ckpt["scheduler"], logger=logger
+            )
             scaler.load_state_dict(resume_ckpt["scaler"])
             start_epoch = int(resume_ckpt["epoch"]) + 1
             best_val_loss = float(resume_ckpt.get("best_val_loss", float("inf")))

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -49,6 +49,7 @@ from deepcell_types.training.utils import (
     seed_everything,
     build_label_remap,
     load_matching_state_dict,
+    resume_onecycle_schedule,
 )
 
 logger = logging.getLogger(__name__)
@@ -689,7 +690,13 @@ def main(
 
             model.load_state_dict(resume_ckpt["model"])
             optimizer.load_state_dict(resume_ckpt["optimizer"])
-            scheduler.load_state_dict(resume_ckpt["scheduler"])
+            # See resume_onecycle_schedule() docstring: a naive
+            # scheduler.load_state_dict() here would silently overwrite
+            # total_steps with the checkpointed run's value, discarding an
+            # increased --epochs.
+            resume_onecycle_schedule(
+                scheduler, resume_ckpt["scheduler"], logger=logger
+            )
             scaler.load_state_dict(resume_ckpt["scaler"])
             start_epoch = int(resume_ckpt["epoch"]) + 1
             # New key "best_val_macro_f1"; fall back to the legacy

--- a/tests/baselines/test_nimbus_coverage_gate.py
+++ b/tests/baselines/test_nimbus_coverage_gate.py
@@ -1,0 +1,55 @@
+"""Coverage-accounting test for the Nimbus baseline's FOV-loading loop.
+
+``check_dataset_coverage`` is the pure helper extracted from ``main()`` (the
+loop itself needs a real/mocked zarr archive + Nimbus model, so isn't
+directly unit-testable). It must always report the skipped/failed dataset
+count, and raise ``RuntimeError`` only once the failure rate exceeds the 1%
+threshold that mirrors ``training/dataset.py``'s cell-data cache build gate
+(see ``deepcell_types/training/dataset.py``, ``failed_keys`` / ``fail_rate``).
+Baselines are scored at full coverage (``deepcell_types/abstention.py``), so
+a silent drop must never be invisible — hence the aggregate print happens
+unconditionally, even below threshold.
+"""
+
+import pytest
+
+from deepcell_types.baselines.nimbus.run import (
+    NIMBUS_DATASET_FAILURE_RATE_THRESHOLD,
+    check_dataset_coverage,
+)
+
+
+def test_no_skips_reports_zero_and_does_not_raise(capsys):
+    check_dataset_coverage(skipped_keys=[], total_keys=100)
+    out = capsys.readouterr().out
+    assert "Skipped 0 of 100 datasets" in out
+
+
+def test_below_threshold_reports_but_does_not_raise(capsys):
+    # 1 of 100 == 1.0%, at (not above) the default 1% threshold -> no raise.
+    check_dataset_coverage(skipped_keys=["ds_bad"], total_keys=100)
+    out = capsys.readouterr().out
+    assert "Skipped 1 of 100 datasets" in out
+
+
+def test_above_threshold_raises_runtime_error(capsys):
+    skipped = [f"ds_bad_{i}" for i in range(5)]
+    with pytest.raises(RuntimeError, match="above the 1% safety threshold"):
+        check_dataset_coverage(skipped_keys=skipped, total_keys=100)
+    # The aggregate line is printed before the raise, so it's never silent.
+    out = capsys.readouterr().out
+    assert "Skipped 5 of 100 datasets" in out
+
+
+def test_custom_threshold_is_respected(capsys):
+    # 2 of 100 == 2%, above a tightened 1.5% threshold.
+    with pytest.raises(RuntimeError, match="above the 2% safety threshold"):
+        check_dataset_coverage(
+            skipped_keys=["a", "b"], total_keys=100, threshold=0.015
+        )
+
+
+def test_default_threshold_constant_matches_convention():
+    # Pins the module constant to the training/dataset.py cache-build
+    # convention (>1% dataset drop is a schema regression, not noise).
+    assert NIMBUS_DATASET_FAILURE_RATE_THRESHOLD == 0.01

--- a/tests/test_abstention_inference.py
+++ b/tests/test_abstention_inference.py
@@ -9,39 +9,39 @@ inference-only CI job (no ``[train]`` dependency).
 
 import numpy as np
 
-from deepcell_types.abstention import ABSTENTION_LABEL, compute_iqr_fence
+from deepcell_types.abstention import ABSTENTION_LABEL, _compute_iqr_fence
 
 
 def test_returns_none_below_four_values():
-    assert compute_iqr_fence(np.array([0.4, 0.6, 0.9]), 1.5) is None
-    assert compute_iqr_fence(np.array([]), 0.2) is None
+    assert _compute_iqr_fence(np.array([0.4, 0.6, 0.9]), 1.5) is None
+    assert _compute_iqr_fence(np.array([]), 0.2) is None
 
 
 def test_known_fence_value():
     vals = np.array([0.1, 0.3, 0.5, 0.7, 0.9])
     q1, q3 = np.quantile(vals, [0.25, 0.75])
-    assert compute_iqr_fence(vals, 0.2) == float(q1 - 0.2 * (q3 - q1))
+    assert _compute_iqr_fence(vals, 0.2) == float(q1 - 0.2 * (q3 - q1))
 
 
 def test_k_zero_gives_q1():
     vals = np.array([0.1, 0.2, 0.8, 0.9])
-    assert compute_iqr_fence(vals, 0.0) == float(np.quantile(vals, 0.25))
+    assert _compute_iqr_fence(vals, 0.0) == float(np.quantile(vals, 0.25))
 
 
 def test_degenerate_iqr_returns_q1():
     # All-equal confidences => IQR == 0 => fence == Q1, regardless of k.
-    assert compute_iqr_fence(np.array([0.5, 0.5, 0.5, 0.5]), 1.5) == 0.5
+    assert _compute_iqr_fence(np.array([0.5, 0.5, 0.5, 0.5]), 1.5) == 0.5
 
 
 def test_non_finite_values_are_dropped():
     finite = np.array([0.1, 0.3, 0.5, 0.7, 0.9])
     with_bad = np.array([0.1, 0.3, np.nan, 0.5, 0.7, np.inf, 0.9])
     # Dropping NaN/inf must reproduce the finite-only fence, not poison it to NaN.
-    assert compute_iqr_fence(with_bad, 0.2) == compute_iqr_fence(finite, 0.2)
+    assert _compute_iqr_fence(with_bad, 0.2) == _compute_iqr_fence(finite, 0.2)
 
 
 def test_all_non_finite_returns_none():
-    assert compute_iqr_fence(np.array([np.nan, np.inf, -np.inf, np.nan]), 0.2) is None
+    assert _compute_iqr_fence(np.array([np.nan, np.inf, -np.inf, np.nan]), 0.2) is None
 
 
 def test_abstention_label_sentinel():

--- a/tests/test_canonical_inference.py
+++ b/tests/test_canonical_inference.py
@@ -161,6 +161,15 @@ def test_patch_dataset_shards_iterable_workers_without_duplicates(tmp_path):
     assert len(cell_indices) == len(set(cell_indices)) == len(dataset)
 
 
+def test_patch_dataset_rejects_raw_mask_spatial_mismatch(tmp_path):
+    archive_path = _make_archive(tmp_path)
+    config = DCTConfig(zarr_path=archive_path)
+    raw = np.ones((1, 40, 40), dtype=np.float32)
+    mask = np.zeros((32, 32), dtype=np.int32)
+    with pytest.raises(ValueError, match="raw spatial shape"):
+        PatchDataset(raw, mask, ["CD45"], 0.5, config)
+
+
 def test_model_path_treats_dotted_model_names_as_cached_models():
     model_cache = Path.home() / ".deepcell" / "models"
 
@@ -909,3 +918,23 @@ def test_marker_ordering_uses_indices_not_dict_insertion():
             {"A": 0, "B": 1},
             {"M1": 1, "M2": 0},
         )
+
+
+def test_checkpoint_without_canonical_channels_is_rejected():
+    """A checkpoint that bundles ct2idx but not canonical_channels is rejected
+    outright: the marker ordering cannot be verified and a permuted marker
+    vocabulary would silently mislabel every cell."""
+    config = DCTConfig()  # packaged vocab.json -> canonical 51-class ordering
+    ckpt = {"ct2idx": dict(config.ct2idx)}
+    with pytest.raises(ValueError, match="does not bundle canonical_channels"):
+        validate_checkpoint_vocabulary(ckpt, config.ct2idx, config.marker2idx)
+
+
+def test_checkpoint_with_matching_ct2idx_and_canonical_channels_is_accepted():
+    """Both ct2idx and canonical_channels present and matching -> no error."""
+    config = DCTConfig()
+    ckpt = {
+        "ct2idx": dict(config.ct2idx),
+        "canonical_channels": list(config.marker2idx.keys()),
+    }
+    validate_checkpoint_vocabulary(ckpt, config.ct2idx, config.marker2idx)

--- a/tests/test_ct_abstention_cli.py
+++ b/tests/test_ct_abstention_cli.py
@@ -1,7 +1,7 @@
 """Tests for the post-hoc CT abstention wired into scripts/predict.py.
 
 Exercises the lower-level building blocks in `deepcell_types.abstention` —
-`compute_iqr_fence` and `apply_abstention` — that the CLI wires up. Five
+`_compute_iqr_fence` and `apply_abstention` — that the CLI wires up. Five
 scenarios are covered:
 
 1. Default (no abstention applied) — `apply_abstention` not called → no
@@ -22,8 +22,8 @@ import pytest
 
 from deepcell_types.abstention import (
     ABSTENTION_LABEL,
+    _compute_iqr_fence,
     apply_abstention,
-    compute_iqr_fence,
 )
 
 
@@ -174,8 +174,8 @@ def test_compute_iqr_fence_returns_none_under_threshold():
     """Tiny samples (<4) cannot define an IQR; helper returns None and the
     caller must not abstain anything in that group.
     """
-    assert compute_iqr_fence(np.array([0.5, 0.6, 0.7]), 1.5) is None
-    f = compute_iqr_fence(np.array([0.1, 0.2, 0.3, 0.4]), 1.5)
+    assert _compute_iqr_fence(np.array([0.5, 0.6, 0.7]), 1.5) is None
+    f = _compute_iqr_fence(np.array([0.1, 0.2, 0.3, 0.4]), 1.5)
     assert f is not None
     assert f == pytest.approx(0.175 - 1.5 * 0.15)
 

--- a/tests/test_dataloader_integration.py
+++ b/tests/test_dataloader_integration.py
@@ -1,0 +1,241 @@
+"""End-to-end tests for ``FullImageDataset.__getitem__`` and
+``create_dataloader`` against a real (synthetic) training-shaped zarr
+archive.
+
+Previously ``FullImageDataset`` was only exercised via ``__new__``-stubs
+(``tests/test_channel_aliases.py``) or reimplemented fragments
+(``tests/test_zero_channel_masking.py``); no test constructed a real instance
+end-to-end or drove a real ``DataLoader`` batch. This builds a tiny archive
+(2 FOVs, 4 cells, 3 classes; one FOV has an all-zero acquisition channel) via
+the real ``zarr`` library — the layout ``TissueNetConfig``/``FullImageDataset``
+read in production.
+"""
+
+import numpy as np
+import pytest
+import torch
+import zarr
+
+from deepcell_types.training.config import TissueNetConfig
+from deepcell_types.training.dataset import FullImageDataset, create_dataloader
+from deepcell_types.training.utils import BatchData
+
+
+def _make_archive(root_path):
+    """2 FOVs, 4 cells, 3 classes.
+
+    ``fov_a`` (IMC/lung): CD68 (channel index 2) is all-zero across the whole
+    FOV — acquisition-empty, exercising the FOV-zero-channel masking path in
+    ``__getitem__``. ``fov_b`` (CODEX/liver): all 3 channels carry signal.
+    """
+    root = zarr.open_group(str(root_path), mode="w")
+    root.attrs["cell_type_mapping"] = {"Bcell": 0, "Tumor": 1, "Myeloid": 2}
+    root.attrs["all_standardized_channels"] = ["CD45", "PanCK", "CD68"]
+    root.attrs["all_standardized_cell_types"] = ["Bcell", "Tumor", "Myeloid"]
+
+    rng = np.random.default_rng(0)
+
+    g = root.create_group("fov_a")
+    g.attrs["modality"] = "IMC"
+    g.attrs["tissue"] = "lung"
+    ann = g.create_group("cell_types").create_group("annotations")
+    ann.attrs["standardized_source"] = {"Bcell": [1], "Tumor": [2]}
+    preproc = g.create_group("preprocessed")
+    preproc.attrs["channel_names"] = ["CD45", "PanCK", "CD68"]
+    preproc.attrs["centroids"] = {"1": [16, 16], "2": [16, 48]}
+    raw = rng.random((3, 64, 64), dtype=np.float64).astype(np.float32) + 0.1
+    raw[2] = 0.0  # CD68 acquisition-empty on this FOV
+    preproc["raw"] = raw
+    mask = np.zeros((64, 64), dtype=np.int32)
+    mask[10:22, 10:22] = 1
+    mask[10:22, 42:54] = 2
+    preproc["mask"] = mask
+
+    g2 = root.create_group("fov_b")
+    g2.attrs["modality"] = "CODEX"
+    g2.attrs["tissue"] = "liver"
+    ann2 = g2.create_group("cell_types").create_group("annotations")
+    ann2.attrs["standardized_source"] = {"Tumor": [1], "Myeloid": [2]}
+    preproc2 = g2.create_group("preprocessed")
+    preproc2.attrs["channel_names"] = ["CD45", "PanCK", "CD68"]
+    preproc2.attrs["centroids"] = {"1": [16, 16], "2": [16, 48]}
+    raw2 = rng.random((3, 64, 64), dtype=np.float64).astype(np.float32) + 0.1
+    preproc2["raw"] = raw2
+    mask2 = np.zeros((64, 64), dtype=np.int32)
+    mask2[10:22, 10:22] = 1
+    mask2[10:22, 42:54] = 2
+    preproc2["mask"] = mask2
+
+    return root_path
+
+
+@pytest.fixture
+def archive_and_config(tmp_path):
+    archive_path = tmp_path / "train.zarr"
+    _make_archive(archive_path)
+    config = TissueNetConfig(archive_path)
+    return archive_path, config
+
+
+def test_config_reads_training_archive_contract(archive_and_config):
+    archive_path, config = archive_and_config
+    assert config.ct2idx == {"Bcell": 0, "Tumor": 1, "Myeloid": 2}
+    assert config.marker2idx == {"CD45": 0, "PanCK": 1, "CD68": 2}
+    assert config.domain2idx == {"CODEX": 0, "IMC": 1}
+    assert config.tissue2idx == {"liver": 0, "lung": 1}
+
+
+def test_full_image_dataset_indexes_all_cells(archive_and_config):
+    archive_path, config = archive_and_config
+    dataset = FullImageDataset(archive_path, dct_config=config)
+
+    assert len(dataset) == 4
+    fov_names = {rec.fov_name for rec in dataset.indices}
+    assert fov_names == {"fov_a", "fov_b"}
+    ct_labels = sorted(rec.ct_label_standard for rec in dataset.indices)
+    assert ct_labels == ["Bcell", "Myeloid", "Tumor", "Tumor"]
+
+
+def test_getitem_returns_correctly_shaped_and_typed_tensors(archive_and_config):
+    archive_path, config = archive_and_config
+    dataset = FullImageDataset(archive_path, dct_config=config)
+
+    (
+        sample,
+        spatial_context,
+        ch_idx,
+        attn_mask,
+        ct_idx,
+        domain_idx,
+        mp,
+        vm,
+        cell_idx,
+        dataset_name,
+        fov_name,
+        tissue_idx,
+    ) = dataset[0]
+
+    max_channels = dataset.max_channels  # 80 (dct_config.MAX_NUM_CHANNELS)
+    crop = dataset.output_size  # 32
+
+    assert sample.shape == (max_channels, 1, crop, crop)
+    assert sample.dtype == torch.float32
+    assert spatial_context.shape == (3, crop, crop)
+    assert spatial_context.dtype == torch.float32
+    assert ch_idx.shape == (max_channels,)
+    assert ch_idx.dtype == torch.int64
+    assert attn_mask.shape == (max_channels,)
+    assert attn_mask.dtype == torch.bool
+    assert mp.shape == (max_channels,)
+    assert mp.dtype == torch.float32
+    assert vm.shape == (max_channels,)
+    assert vm.dtype == torch.bool
+    assert isinstance(ct_idx, int)
+    assert isinstance(domain_idx, int)
+    assert isinstance(cell_idx, int)
+    assert isinstance(dataset_name, str)
+    assert isinstance(fov_name, str)
+    assert tissue_idx.shape == ()
+    assert tissue_idx.dtype == torch.int64
+
+    # Only the first 3 channel slots are real (CD45, PanCK, CD68); the rest
+    # are padding (ch_idx == -1).
+    assert ch_idx[:3].tolist() == [0, 1, 2]
+    assert (ch_idx[3:] == -1).all()
+    assert attn_mask[3:].all()  # padding is always attention-masked
+
+
+def test_getitem_masks_all_zero_channel_for_affected_fov_only(archive_and_config):
+    """fov_a's CD68 (channel slot 2) is all-zero across the FOV and must be
+    attention-masked (attn_mask[2] == True) for BOTH of its cells, while
+    fov_b's CD68 carries real signal and is unmasked."""
+    archive_path, config = archive_and_config
+    dataset = FullImageDataset(archive_path, dct_config=config)
+
+    for i, record in enumerate(dataset.indices):
+        item = dataset[i]
+        attn_mask = item[3]
+        sample = item[0]
+        if record.fov_name == "fov_a":
+            assert bool(attn_mask[0]) is False  # CD45: real signal
+            assert bool(attn_mask[1]) is False  # PanCK: real signal
+            assert bool(attn_mask[2]) is True  # CD68: acquisition-empty -> masked
+            # Masked-out channel's sample is cleared to the -1.0 padding sentinel.
+            assert torch.all(sample[2] == -1.0)
+        else:
+            assert record.fov_name == "fov_b"
+            assert bool(attn_mask[0]) is False
+            assert bool(attn_mask[1]) is False
+            assert bool(attn_mask[2]) is False  # CD68 has real signal here
+
+
+def test_getitem_self_mask_is_nonempty(archive_and_config):
+    """spatial_context[0] is the self-mask; a labeled cell must have a
+    non-empty self-mask (the production tripwire in __getitem__)."""
+    archive_path, config = archive_and_config
+    dataset = FullImageDataset(archive_path, dct_config=config)
+    for i in range(len(dataset)):
+        spatial_context = dataset[i][1]
+        assert float(spatial_context[0].sum()) > 0
+
+
+def test_create_dataloader_only_test_yields_correctly_shaped_batch(archive_and_config):
+    archive_path, config = archive_and_config
+
+    train_loader, test_loader, metadata = create_dataloader(
+        zarr_dir=archive_path,
+        dct_config=config,
+        batch_size=2,
+        num_workers=0,
+        only_test=True,
+    )
+
+    assert train_loader is None
+    assert metadata["num_samples"] == 4
+
+    batch = next(iter(test_loader))
+    batch_data = BatchData(*batch)
+
+    B = 2
+    max_channels = config.MAX_NUM_CHANNELS
+    crop = config.OUTPUT_SIZE
+
+    assert batch_data.sample.shape == (B, max_channels, 1, crop, crop)
+    assert batch_data.spatial_context.shape == (B, 3, crop, crop)
+    assert batch_data.ch_idx.shape == (B, max_channels)
+    assert batch_data.mask.shape == (B, max_channels)
+    assert batch_data.ct_idx.shape == (B,)
+    assert batch_data.domain_idx.shape == (B,)
+    assert batch_data.marker_positivity.shape == (B, max_channels)
+    assert batch_data.marker_positivity_mask.shape == (B, max_channels)
+    assert batch_data.cell_index.shape == (B,)
+    assert len(batch_data.dataset_name) == B
+    assert len(batch_data.fov_name) == B
+    assert batch_data.tissue_idx.shape == (B,)
+
+    # Every batch element assembled without error and cell types/domains
+    # resolve to valid indices.
+    assert set(batch_data.ct_idx.tolist()) <= set(config.ct2idx.values())
+    assert set(batch_data.domain_idx.tolist()) <= set(config.domain2idx.values())
+
+
+def test_create_dataloader_only_test_covers_all_cells_across_batches(archive_and_config):
+    archive_path, config = archive_and_config
+
+    _, test_loader, metadata = create_dataloader(
+        zarr_dir=archive_path,
+        dct_config=config,
+        batch_size=2,
+        num_workers=0,
+        only_test=True,
+    )
+
+    seen_cell_index = []
+    seen_dataset = []
+    for batch in test_loader:
+        batch_data = BatchData(*batch)
+        seen_cell_index.extend(batch_data.cell_index.tolist())
+        seen_dataset.extend(batch_data.dataset_name)
+
+    assert len(seen_cell_index) == metadata["num_samples"] == 4
+    assert sorted(seen_dataset) == ["fov_a", "fov_a", "fov_b", "fov_b"]

--- a/tests/test_gold_metadata.py
+++ b/tests/test_gold_metadata.py
@@ -1,0 +1,150 @@
+"""Tests for ``deepcell_types.training.gold_metadata.resolve_gold_metadata``.
+
+Covers: known-key resolution, unknown-key errors, the ``strict`` refusal of
+non-canonical substitutions, and the ``dct_config`` vocab-validation branch.
+"""
+
+import pytest
+
+from deepcell_types.training.gold_metadata import (
+    GOLD_DATASET_METADATA,
+    NONCANONICAL_DATASETS,
+    resolve_gold_metadata,
+)
+
+
+class _ConfigStub:
+    """Minimal stand-in for ``TissueNetConfig``: only ``tissue2idx`` /
+    ``domain2idx`` are read by ``resolve_gold_metadata``."""
+
+    def __init__(self, tissue2idx=None, domain2idx=None):
+        self.tissue2idx = {} if tissue2idx is None else tissue2idx
+        self.domain2idx = {} if domain2idx is None else domain2idx
+
+
+# --- known-key resolution ---------------------------------------------------
+
+
+@pytest.mark.parametrize("dataset_key", sorted(GOLD_DATASET_METADATA))
+def test_known_key_resolves_to_canonical_tuple(dataset_key):
+    meta = GOLD_DATASET_METADATA[dataset_key]
+    tissue, modality = resolve_gold_metadata(dataset_key)
+    assert (tissue, modality) == (meta["tissue_canonical"], meta["modality_canonical"])
+
+
+def test_all_five_pan_m_subsets_are_registered():
+    # Pin the known Pan-M Gold-Standard subset roster (per the module docstring).
+    assert set(GOLD_DATASET_METADATA) == {
+        "codex_colon",
+        "mibi_breast",
+        "mibi_decidua",
+        "vectra_colon",
+        "vectra_pancreas",
+    }
+
+
+# --- unknown key -------------------------------------------------------------
+
+
+def test_unknown_dataset_key_raises_keyerror():
+    with pytest.raises(KeyError):
+        resolve_gold_metadata("not_a_real_dataset")
+
+
+def test_unknown_dataset_key_error_lists_valid_keys():
+    with pytest.raises(KeyError, match="not_a_real_dataset"):
+        resolve_gold_metadata("not_a_real_dataset")
+
+
+# --- strict=True refuses non-canonical substitutions ------------------------
+
+
+def test_noncanonical_dataset_roster():
+    # Pin the actual NONCANONICAL_DATASETS names this test parametrizes over.
+    assert NONCANONICAL_DATASETS == frozenset(
+        {"mibi_decidua", "vectra_colon", "vectra_pancreas"}
+    )
+
+
+@pytest.mark.parametrize("dataset_key", sorted(NONCANONICAL_DATASETS))
+def test_strict_raises_for_noncanonical_dataset(dataset_key):
+    with pytest.raises(ValueError, match="non-direct"):
+        resolve_gold_metadata(dataset_key, strict=True)
+
+
+@pytest.mark.parametrize(
+    "dataset_key", sorted(set(GOLD_DATASET_METADATA) - NONCANONICAL_DATASETS)
+)
+def test_strict_does_not_raise_for_canonical_dataset(dataset_key):
+    meta = GOLD_DATASET_METADATA[dataset_key]
+    tissue, modality = resolve_gold_metadata(dataset_key, strict=True)
+    assert (tissue, modality) == (meta["tissue_canonical"], meta["modality_canonical"])
+
+
+# --- strict=False (default) accepts the substitution ------------------------
+
+
+@pytest.mark.parametrize("dataset_key", sorted(NONCANONICAL_DATASETS))
+def test_non_strict_returns_substituted_tuple(dataset_key):
+    meta = GOLD_DATASET_METADATA[dataset_key]
+    tissue, modality = resolve_gold_metadata(dataset_key, strict=False)
+    assert (tissue, modality) == (meta["tissue_canonical"], meta["modality_canonical"])
+
+
+def test_default_strict_is_false():
+    # codex_colon is canonical either way; use a noncanonical key to prove the
+    # default doesn't raise (i.e. strict defaults to False).
+    tissue, modality = resolve_gold_metadata("mibi_decidua")
+    assert (tissue, modality) == ("uterus", "mibi")
+
+
+# --- dct_config vocab-validation branch -------------------------------------
+
+
+def test_dct_config_none_skips_validation():
+    # No dct_config -> no vocab check performed, resolution still succeeds.
+    tissue, modality = resolve_gold_metadata("codex_colon", dct_config=None)
+    assert (tissue, modality) == ("colon", "codex")
+
+
+def test_dct_config_validation_passes_when_vocab_contains_names():
+    config = _ConfigStub(tissue2idx={"colon": 0}, domain2idx={"codex": 0})
+    tissue, modality = resolve_gold_metadata("codex_colon", dct_config=config)
+    assert (tissue, modality) == ("colon", "codex")
+
+
+def test_dct_config_validation_raises_when_tissue_missing():
+    config = _ConfigStub(tissue2idx={}, domain2idx={"codex": 0})
+    with pytest.raises(ValueError, match="tissue2idx"):
+        resolve_gold_metadata("codex_colon", dct_config=config)
+
+
+def test_dct_config_validation_raises_when_modality_missing():
+    config = _ConfigStub(tissue2idx={"colon": 0}, domain2idx={})
+    with pytest.raises(ValueError, match="domain2idx"):
+        resolve_gold_metadata("codex_colon", dct_config=config)
+
+
+def test_dct_config_validation_checks_tissue_before_modality():
+    # Both missing -> the tissue check fires first (raises on tissue, not modality).
+    config = _ConfigStub(tissue2idx={}, domain2idx={})
+    with pytest.raises(ValueError, match="Resolved tissue"):
+        resolve_gold_metadata("codex_colon", dct_config=config)
+
+
+def test_dct_config_without_tissue2idx_attr_treated_as_empty():
+    # getattr(..., "tissue2idx", {}) fallback: an object missing the attribute
+    # entirely behaves like an empty vocab, not a crash.
+    class _BareObject:
+        pass
+
+    with pytest.raises(ValueError, match="tissue2idx"):
+        resolve_gold_metadata("codex_colon", dct_config=_BareObject())
+
+
+def test_strict_refusal_takes_priority_over_vocab_validation():
+    # strict=True raises the "non-direct canonicalization" error before ever
+    # consulting dct_config, even if the config would also fail vocab checks.
+    config = _ConfigStub(tissue2idx={}, domain2idx={})
+    with pytest.raises(ValueError, match="non-direct"):
+        resolve_gold_metadata("mibi_decidua", dct_config=config, strict=True)

--- a/tests/test_public_listing_api.py
+++ b/tests/test_public_listing_api.py
@@ -1,0 +1,29 @@
+"""Unit tests for the public registry-listing helpers (``list_supported_markers`` /
+``list_supported_cell_types``). These let a user pre-flight-check their marker
+panel against the packaged registry before downloading a checkpoint; they must
+stay importable from the top-level package and free of a torch import (same
+inference/train dependency split guarded by ``test_inference_deps.py``).
+"""
+
+import deepcell_types
+from deepcell_types import list_supported_cell_types, list_supported_markers
+from deepcell_types.config import DCTConfig
+
+
+def test_list_supported_markers_matches_config():
+    markers = list_supported_markers()
+    assert markers == sorted(markers)
+    assert markers
+    assert set(markers) == set(DCTConfig().marker2idx)
+
+
+def test_list_supported_cell_types_matches_config():
+    cell_types = list_supported_cell_types()
+    assert cell_types == sorted(cell_types)
+    assert cell_types
+    assert set(cell_types) == set(DCTConfig().ct2idx)
+
+
+def test_listing_helpers_importable_from_top_level_package():
+    assert deepcell_types.list_supported_markers is list_supported_markers
+    assert deepcell_types.list_supported_cell_types is list_supported_cell_types

--- a/tests/test_public_listing_api.py
+++ b/tests/test_public_listing_api.py
@@ -6,7 +6,11 @@ inference/train dependency split guarded by ``test_inference_deps.py``).
 """
 
 import deepcell_types
-from deepcell_types import list_supported_cell_types, list_supported_markers
+from deepcell_types import (
+    list_supported_cell_types,
+    list_supported_markers,
+    resolve_supported_marker,
+)
 from deepcell_types.config import DCTConfig
 
 
@@ -27,3 +31,12 @@ def test_list_supported_cell_types_matches_config():
 def test_listing_helpers_importable_from_top_level_package():
     assert deepcell_types.list_supported_markers is list_supported_markers
     assert deepcell_types.list_supported_cell_types is list_supported_cell_types
+    assert deepcell_types.resolve_supported_marker is resolve_supported_marker
+
+
+def test_resolve_supported_marker_matches_inference_resolution():
+    assert resolve_supported_marker("PanCK") == "PanCK"
+    assert resolve_supported_marker("PANCK") == "PanCK"
+    assert resolve_supported_marker("panck") == "PanCK"
+    assert resolve_supported_marker("Pan-Cytokeratin") == "PanCK"
+    assert resolve_supported_marker("not-a-supported-marker") is None

--- a/tests/test_resume_onecycle_schedule.py
+++ b/tests/test_resume_onecycle_schedule.py
@@ -1,0 +1,136 @@
+"""Unit tests for resume_onecycle_schedule (deepcell_types/training/utils.py).
+
+Bug this guards against: `--resume_path` combined with an increased
+`--epochs` used to silently discard the new (longer) OneCycleLR schedule.
+`torch.optim.lr_scheduler.LRScheduler.load_state_dict` is a raw
+`self.__dict__.update(state_dict)`, so `scheduler.load_state_dict(ckpt["scheduler"])`
+overwrote the freshly-built scheduler's `total_steps` (and derived
+`_schedule_phases`) with the CHECKPOINTED run's (shorter) values — training
+then continued to anneal toward the OLD, already-passed total_steps instead
+of the new one, and a resumed run that stepped past the old total_steps would
+even raise inside OneCycleLR.get_lr().
+
+resume_onecycle_schedule() is a small importable helper factored out of
+scripts/train.py's/pretrain.py's --resume_path block specifically so this
+adjust logic is unit-testable without running real training.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from deepcell_types.training.utils import resume_onecycle_schedule
+
+# These tests call scheduler.step() directly (no optimizer.step() in
+# between), which is exactly what the checkpoint fast-forward path does.
+# The resulting UserWarning is expected noise, same suppression used by
+# tests/test_train_loop_smoke.py.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Detected call of `lr_scheduler.step\\(\\)`:UserWarning"
+)
+
+
+class _TinyNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc = nn.Linear(4, 3)
+
+    def forward(self, x):
+        return self.fc(x)
+
+
+def _build_onecycle(total_steps):
+    model = _TinyNet()
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)
+    scheduler = torch.optim.lr_scheduler.OneCycleLR(
+        optimizer,
+        max_lr=1e-3,
+        total_steps=total_steps,
+        pct_start=0.3,
+        anneal_strategy="cos",
+    )
+    return optimizer, scheduler
+
+
+class TestResumeOnecycleScheduleUnchangedEpochs:
+    def test_matching_total_steps_loads_verbatim(self):
+        """--epochs unchanged: behavior is identical to a plain load_state_dict."""
+        _, old_scheduler = _build_onecycle(total_steps=50)
+        for _ in range(30):
+            old_scheduler.step()
+        old_state = old_scheduler.state_dict()
+        old_last_lr = old_scheduler.get_last_lr()
+
+        _, new_scheduler = _build_onecycle(total_steps=50)
+        resume_onecycle_schedule(new_scheduler, old_state)
+
+        assert new_scheduler.total_steps == 50
+        assert new_scheduler.last_epoch == 30
+        assert new_scheduler.get_last_lr() == old_last_lr
+
+
+class TestResumeOnecycleScheduleChangedEpochs:
+    def test_longer_epochs_rebuilds_total_steps_and_preserves_position(self):
+        """--epochs increased: total_steps reflects the NEW run, not the checkpoint."""
+        _, old_scheduler = _build_onecycle(total_steps=50)
+        for _ in range(30):
+            old_scheduler.step()
+        old_state = old_scheduler.state_dict()
+        assert old_state["total_steps"] == 50
+        assert old_state["last_epoch"] == 30
+
+        _, new_scheduler = _build_onecycle(total_steps=200)
+        resume_onecycle_schedule(new_scheduler, old_state)
+
+        # total_steps must reflect the NEW (longer) run, not the checkpoint's.
+        assert new_scheduler.total_steps == 200
+        # LR position (how many steps already trained) is preserved.
+        assert new_scheduler.last_epoch == 30
+
+    def test_can_step_past_old_total_steps_without_raising(self):
+        """The whole point of the fix: training can continue past the OLD
+        total_steps (50) because the schedule now runs to the NEW total_steps
+        (200). Before the fix, a blind load_state_dict() would leave
+        total_steps=50, and OneCycleLR.get_lr() raises once last_epoch
+        exceeds total_steps.
+        """
+        _, old_scheduler = _build_onecycle(total_steps=50)
+        for _ in range(30):
+            old_scheduler.step()
+        old_state = old_scheduler.state_dict()
+
+        _, new_scheduler = _build_onecycle(total_steps=200)
+        resume_onecycle_schedule(new_scheduler, old_state)
+
+        # Step from 30 up to 150 total steps — well past the checkpoint's
+        # old total_steps=50, but comfortably inside the new total_steps=200.
+        for _ in range(120):
+            new_scheduler.step()
+        assert new_scheduler.last_epoch == 150
+        # No exception raised means the rebuilt schedule is in effect.
+
+    def test_shorter_epochs_that_still_covers_completed_steps_rebuilds(self):
+        """A smaller-but-still-sufficient new total_steps also rebuilds cleanly."""
+        _, old_scheduler = _build_onecycle(total_steps=100)
+        for _ in range(10):
+            old_scheduler.step()
+        old_state = old_scheduler.state_dict()
+
+        _, new_scheduler = _build_onecycle(total_steps=40)
+        resume_onecycle_schedule(new_scheduler, old_state)
+
+        assert new_scheduler.total_steps == 40
+        assert new_scheduler.last_epoch == 10
+
+    def test_resumed_steps_exceeding_new_total_steps_raises_clear_error(self):
+        """Guard: if the checkpoint is already further along than the new
+        --epochs allows, fail loudly instead of corrupting the schedule.
+        """
+        _, old_scheduler = _build_onecycle(total_steps=100)
+        for _ in range(80):
+            old_scheduler.step()
+        old_state = old_scheduler.state_dict()
+
+        _, new_scheduler = _build_onecycle(total_steps=50)
+        with pytest.raises(ValueError, match="already completed"):
+            resume_onecycle_schedule(new_scheduler, old_state)

--- a/tests/test_scripts_predict_main.py
+++ b/tests/test_scripts_predict_main.py
@@ -1,0 +1,234 @@
+"""End-to-end tests for ``scripts/predict.py::main`` — the evaluation CLI that
+generates the metrics/predictions reported in the paper. Previously only a
+pure helper (``_resolve_marker_embeddings``, see ``test_scripts_predict.py``)
+was covered; ``main`` itself (checkpoint loading, dataloader construction,
+prediction, CSV assembly, optional CT abstention) had zero direct coverage.
+
+Builds a tiny synthetic training-shaped zarr archive (2 FOVs, 4 cells, 3
+classes) via the real ``zarr`` library — the same archive layout
+``FullImageDataset``/``TissueNetConfig`` read in production — plus a matching
+checkpoint, then drives ``main()`` with ``click.testing.CliRunner``.
+"""
+
+import numpy as np
+import pytest
+import torch
+import zarr
+from click.testing import CliRunner
+
+from deepcell_types.model import create_model
+from deepcell_types.training.config import TissueNetConfig
+from scripts.predict import main
+
+
+def _make_archive(root_path):
+    """A minimal but real training-shaped archive: 2 FOVs, 4 cells, 3 classes.
+
+    Layout mirrors production: root attrs carry the vocab, each FOV group has
+    modality/tissue attrs, a ``cell_types/annotations`` group with
+    ``standardized_source`` (cell-index-keyed labels), and a ``preprocessed``
+    group with ``raw``/``mask`` arrays plus ``centroids``.
+    """
+    root = zarr.open_group(str(root_path), mode="w")
+    root.attrs["cell_type_mapping"] = {"Bcell": 0, "Tumor": 1, "Myeloid": 2}
+    root.attrs["all_standardized_channels"] = ["CD45", "PanCK", "CD68"]
+    root.attrs["all_standardized_cell_types"] = ["Bcell", "Tumor", "Myeloid"]
+
+    rng = np.random.default_rng(0)
+
+    def _add_fov(name, modality, tissue, labels):
+        g = root.create_group(name)
+        g.attrs["modality"] = modality
+        g.attrs["tissue"] = tissue
+        ann = g.create_group("cell_types").create_group("annotations")
+        ann.attrs["standardized_source"] = labels
+        preproc = g.create_group("preprocessed")
+        preproc.attrs["channel_names"] = ["CD45", "PanCK", "CD68"]
+        preproc.attrs["centroids"] = {"1": [16, 16], "2": [16, 48]}
+        raw = rng.random((3, 64, 64), dtype=np.float64).astype(np.float32) + 0.1
+        preproc["raw"] = raw
+        mask = np.zeros((64, 64), dtype=np.int32)
+        mask[10:22, 10:22] = 1
+        mask[10:22, 42:54] = 2
+        preproc["mask"] = mask
+
+    _add_fov("fov_a", "IMC", "lung", {"Bcell": [1], "Tumor": [2]})
+    _add_fov("fov_b", "CODEX", "liver", {"Tumor": [1], "Myeloid": [2]})
+    return root_path
+
+
+def _build_checkpoint(config, tmp_path):
+    """Build a small self-describing checkpoint matching scripts/train.py's
+    bundling contract (model + config + ct2idx + canonical_channels), sized
+    small (resnet_base_channels=4, ct_head_width=32, ct_head_depth=1) for a
+    fast CPU forward pass. ``n_layers``/``d_model`` are NOT stored in
+    "config" because ``scripts/predict.py::main`` hardcodes d_model=256 and
+    does not read n_layers from the checkpoint, so the checkpoint's model
+    must be built with the same (default) values main() will use.
+    """
+    marker_embeddings = np.zeros((len(config.marker2idx), 8), dtype=np.float32)
+    model = create_model(
+        config,
+        marker_embeddings,
+        d_model=256,
+        n_heads=8,
+        n_layers=4,
+        resnet_base_channels=4,
+        spatial_pool_size=1,
+        use_conditioned_mp_head=True,
+        compat_marker0_zero=True,
+        ct_head_width=32,
+        ct_head_depth=1,
+    )
+    ckpt_path = tmp_path / "ckpt.pt"
+    torch.save(
+        {
+            "model": model.state_dict(),
+            "config": {
+                "resnet_channels": 4,
+                "spatial_pool_size": 1,
+                "n_heads": 8,
+                "use_conditioned_mp_head": True,
+                "compat_marker0_zero": True,
+            },
+            "ct2idx": dict(config.ct2idx),
+            "canonical_channels": list(config.marker2idx.keys()),
+        },
+        ckpt_path,
+    )
+    return ckpt_path
+
+
+def _run_main(archive_path, ckpt_path, tmp_path, monkeypatch, extra_args=()):
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    args = [
+        "--model_path", str(ckpt_path),
+        "--zarr_dir", str(archive_path),
+        "--device_num", "cpu",
+        "--batch_size", "2",
+        "--num_workers", "0",
+        "--model_name", "test_model",
+        *extra_args,
+    ]
+    return runner.invoke(main, args, catch_exceptions=True)
+
+
+@pytest.fixture
+def archive_and_checkpoint(tmp_path):
+    archive_path = tmp_path / "train.zarr"
+    _make_archive(archive_path)
+    config = TissueNetConfig(archive_path)
+    ckpt_path = _build_checkpoint(config, tmp_path)
+    return archive_path, ckpt_path, config
+
+
+def test_main_runs_to_completion_and_writes_expected_csv(
+    archive_and_checkpoint, tmp_path, monkeypatch
+):
+    archive_path, ckpt_path, config = archive_and_checkpoint
+
+    result = _run_main(
+        archive_path, ckpt_path, tmp_path, monkeypatch, extra_args=["--ct_abstention_k", "0"]
+    )
+
+    assert result.exit_code == 0, result.output + "\n" + repr(result.exception)
+
+    out_csv = tmp_path / "output" / "test_model_prediction.csv"
+    assert out_csv.exists()
+
+    import pandas as pd
+
+    df = pd.read_csv(out_csv)
+    class_cols = sorted(config.ct2idx, key=config.ct2idx.get)
+    expected_cols = class_cols + [
+        "cell_type_actual",
+        "cell_index",
+        "dataset_name",
+        "fov_name",
+    ]
+    assert df.columns.tolist() == expected_cols
+    # 2 FOVs x 2 cells each.
+    assert len(df) == 4
+    # Every row is a valid probability distribution over the class columns.
+    np.testing.assert_allclose(df[class_cols].sum(axis=1).to_numpy(), 1.0, atol=1e-4)
+    assert set(df["cell_type_actual"]) <= set(config.ct2idx)
+    assert set(df["dataset_name"]) == {"fov_a", "fov_b"}
+
+
+def test_main_ct_abstention_k_zero_omits_abstention_columns(
+    archive_and_checkpoint, tmp_path, monkeypatch
+):
+    """k<=0 (the default) writes the frame as-is: no predicted_ct/abstained
+    columns, matching the historical disabled-path output."""
+    archive_path, ckpt_path, config = archive_and_checkpoint
+
+    result = _run_main(
+        archive_path, ckpt_path, tmp_path, monkeypatch, extra_args=["--ct_abstention_k", "0"]
+    )
+    assert result.exit_code == 0, result.output
+
+    import pandas as pd
+
+    df = pd.read_csv(tmp_path / "output" / "test_model_prediction.csv")
+    assert "predicted_ct" not in df.columns
+    assert "abstained" not in df.columns
+    assert "predicted_ct_raw" not in df.columns
+    assert "CT abstention enabled" not in result.output
+
+
+def test_main_ct_abstention_k_nonzero_adds_abstention_columns(
+    archive_and_checkpoint, tmp_path, monkeypatch
+):
+    """k>0 enables the IQR-fence abstention path: predicted_ct/abstained/
+    predicted_ct_raw columns are added and coverage/macro-F1 are reported."""
+    archive_path, ckpt_path, config = archive_and_checkpoint
+
+    result = _run_main(
+        archive_path, ckpt_path, tmp_path, monkeypatch, extra_args=["--ct_abstention_k", "0.2"]
+    )
+    assert result.exit_code == 0, result.output
+
+    import pandas as pd
+
+    df = pd.read_csv(tmp_path / "output" / "test_model_prediction.csv")
+    assert "predicted_ct" in df.columns
+    assert "abstained" in df.columns
+    assert "predicted_ct_raw" in df.columns
+    assert set(df["predicted_ct"]) <= set(config.ct2idx)
+    assert df["abstained"].dtype == bool
+
+    assert "CT abstention enabled (k=0.2)" in result.output
+    assert "Coverage:" in result.output
+
+
+def test_main_reports_hierarchical_macro_f1_pre_and_post_abstention(
+    archive_and_checkpoint, tmp_path, monkeypatch
+):
+    """When abstention is enabled, main() prints the pre-abstention (full
+    coverage) and post-abstention (kept cells) hierarchical macro-F1 so a
+    human running the CLI can see the abstention/accuracy tradeoff."""
+    archive_path, ckpt_path, config = archive_and_checkpoint
+
+    result = _run_main(
+        archive_path, ckpt_path, tmp_path, monkeypatch, extra_args=["--ct_abstention_k", "0.2"]
+    )
+    assert result.exit_code == 0, result.output
+
+    assert "Macro F1 on kept cells:" in result.output
+    assert "with no abstention" in result.output
+
+
+def test_main_default_cli_abstention_is_disabled(archive_and_checkpoint, tmp_path, monkeypatch):
+    """--ct_abstention_k defaults to 0.0 (disabled) when the flag is omitted
+    entirely — guards against silently re-enabling the benchmark-tuned
+    default at the CLI layer."""
+    archive_path, ckpt_path, config = archive_and_checkpoint
+
+    result = _run_main(archive_path, ckpt_path, tmp_path, monkeypatch, extra_args=[])
+    assert result.exit_code == 0, result.output
+
+    import pandas as pd
+
+    df = pd.read_csv(tmp_path / "output" / "test_model_prediction.csv")
+    assert "predicted_ct" not in df.columns

--- a/tests/test_split_patient_grouping.py
+++ b/tests/test_split_patient_grouping.py
@@ -1,0 +1,189 @@
+"""Unit tests for group_by_patient (deepcell_types/training/splits.py).
+
+Bug this guards against: create_fov_splits() stratifies only by
+(modality, tissue) and shuffles FOVs within a stratum independently, so a
+single patient's FOVs can straddle train and val. Verified in
+splits/fov_split_valsubset.json: mccaffrey_tb_mibi Patient2/Patient10/
+Patient13 all appear in both train and val.
+
+parse_patient_id()/group_by_patient=True add an OPTIONAL grouping mechanism
+(default off, so existing split files/callers are unaffected) that keeps
+every FOV sharing a parsed "...Patient<N>..." id on the same side of the
+split.
+"""
+from deepcell_types.training.dataset import CellIndexRecord, create_fov_splits
+from deepcell_types.training.splits import parse_patient_id
+
+
+class _MockDatasetWithStrata:
+    def __init__(self, indices, zarr_files):
+        self.indices = indices
+        self.zarr_files = zarr_files
+
+
+def _build_dataset(fov_specs):
+    """fov_specs: list of (fov_key, modality, tissue, ct_label) tuples.
+
+    Each entry creates 1 cell in 1 FOV whose dataset_name/fov_name are both
+    `fov_key` — mirrors the real archive layout (see CellIndexRecord
+    docstring: the v8 layout encodes the FOV path in the dataset key).
+    """
+    indices = []
+    zarr_files = []
+    for i, (fov_key, modality, tissue, ct_label) in enumerate(fov_specs):
+        indices.append(
+            CellIndexRecord(i, ct_label, ct_label, modality, i, fov_key, fov_key, (10, 10))
+        )
+        zarr_files.append(
+            {
+                "name": fov_key,
+                "channel_names": ["DAPI"],
+                "dataset_key": fov_key,
+                "tissue": tissue,
+                "modality": modality,
+            }
+        )
+    return _MockDatasetWithStrata(indices, zarr_files)
+
+
+def _make_patient_fovs(prefix, patient_ns, fovs_per_patient, modality, tissue, ct_label):
+    """Build fov_specs for `fovs_per_patient` FOVs each, for patients in patient_ns."""
+    specs = []
+    for p in patient_ns:
+        for j in range(fovs_per_patient):
+            specs.append((f"{prefix}_Patient{p}-{j}", modality, tissue, ct_label))
+    return specs
+
+
+class TestParsePatientId:
+    def test_known_convention_parsed(self):
+        fov_key = ("mccaffrey_tb_mibi_lung_Patient3-2", "mccaffrey_tb_mibi_lung_Patient3-2")
+        assert parse_patient_id(fov_key) == "mccaffrey_tb_mibi_lung_Patient3"
+
+    def test_different_source_datasets_not_merged(self):
+        """Two unrelated datasets both having a 'Patient3' must not collide."""
+        a = parse_patient_id(("datasetA_Patient3-1", "datasetA_Patient3-1"))
+        b = parse_patient_id(("datasetB_Patient3-1", "datasetB_Patient3-1"))
+        assert a != b
+
+    def test_no_match_returns_none(self):
+        fov_key = ("dryadb004_intestine_codex_B004_CL_reg001", "dryadb004_intestine_codex_B004_CL_reg001")
+        assert parse_patient_id(fov_key) is None
+
+
+class TestGroupByPatientNoLeakage:
+    def test_shared_patient_fovs_land_on_one_side(self):
+        """Several FOVs sharing a patient id, within the same stratum: with
+        grouping enabled, no patient id appears in both train and val.
+        """
+        # 6 patients x 2 FOVs = 12 FOVs, all (MIBI, lung).
+        fov_specs = _make_patient_fovs(
+            "mccaffrey_tb_mibi_lung", range(1, 7), 2, "MIBI", "lung", "CD4T"
+        )
+        ds = _build_dataset(fov_specs)
+        # Break sole-source forcing: add a second class present in every FOV.
+        ds.indices.extend(
+            CellIndexRecord(i, "Bcell", "Bcell", "MIBI", 1000 + i, spec[0], spec[0], (5, 5))
+            for i, spec in enumerate(fov_specs)
+        )
+
+        train_idx, val_idx = create_fov_splits(
+            ds, train_ratio=0.5, seed=0, stratify_by=("modality", "tissue"),
+            group_by_patient=True,
+        )
+        train_fovs = {ds.indices[i][5] for i in train_idx}
+        val_fovs = {ds.indices[i][5] for i in val_idx}
+
+        train_patients = {parse_patient_id((f, f)) for f in train_fovs}
+        val_patients = {parse_patient_id((f, f)) for f in val_fovs}
+
+        assert not (train_patients & val_patients), (
+            f"patient leaked across split: {train_patients & val_patients}"
+        )
+        # Sanity: both sides are non-empty (train_ratio=0.5, 6 patient units).
+        assert train_fovs
+        assert val_fovs
+
+    def test_every_fov_of_a_patient_stays_together(self):
+        """A patient with 3 FOVs must have all 3 (not a subset) on one side."""
+        fov_specs = _make_patient_fovs(
+            "ds_lung", [1, 2], 3, "MIBI", "lung", "CD4T"
+        )
+        ds = _build_dataset(fov_specs)
+        ds.indices.extend(
+            CellIndexRecord(i, "Bcell", "Bcell", "MIBI", 1000 + i, spec[0], spec[0], (5, 5))
+            for i, spec in enumerate(fov_specs)
+        )
+
+        train_idx, val_idx = create_fov_splits(
+            ds, train_ratio=0.5, seed=1, stratify_by=("modality", "tissue"),
+            group_by_patient=True,
+        )
+        train_fovs = {ds.indices[i][5] for i in train_idx}
+        val_fovs = {ds.indices[i][5] for i in val_idx}
+
+        patient1_fovs = {f"ds_lung_Patient1-{j}" for j in range(3)}
+        patient2_fovs = {f"ds_lung_Patient2-{j}" for j in range(3)}
+
+        for patient_fovs in (patient1_fovs, patient2_fovs):
+            in_train = patient_fovs & train_fovs
+            in_val = patient_fovs & val_fovs
+            assert in_train == patient_fovs or in_val == patient_fovs, (
+                f"patient FOVs split across train/val: train={in_train}, val={in_val}"
+            )
+
+
+class TestGroupByPatientBackCompat:
+    def test_disabled_matches_ungrouped_behavior(self):
+        """group_by_patient=False (the default) must reproduce the exact
+        same split as calling create_fov_splits without the parameter at
+        all — i.e. this PR does not change any existing split file.
+        """
+        fov_specs = _make_patient_fovs(
+            "mccaffrey_tb_mibi_lung", range(1, 5), 2, "MIBI", "lung", "CD4T"
+        )
+        ds = _build_dataset(fov_specs)
+        ds.indices.extend(
+            CellIndexRecord(i, "Bcell", "Bcell", "MIBI", 1000 + i, spec[0], spec[0], (5, 5))
+            for i, spec in enumerate(fov_specs)
+        )
+
+        train_default, val_default = create_fov_splits(
+            ds, train_ratio=0.5, seed=0, stratify_by=("modality", "tissue"),
+        )
+        train_explicit_off, val_explicit_off = create_fov_splits(
+            ds, train_ratio=0.5, seed=0, stratify_by=("modality", "tissue"),
+            group_by_patient=False,
+        )
+
+        assert train_default == train_explicit_off
+        assert val_default == val_explicit_off
+
+    def test_disabled_can_still_split_a_single_patient_across_train_and_val(self):
+        """Without grouping, a patient's FOVs are free to land on both
+        sides (the pre-existing, leaky behavior) — confirms the default
+        truly leaves old behavior alone rather than always-grouping.
+        """
+        fov_specs = _make_patient_fovs(
+            "ds_lung", range(1, 9), 2, "MIBI", "lung", "CD4T"
+        )
+        ds = _build_dataset(fov_specs)
+        ds.indices.extend(
+            CellIndexRecord(i, "Bcell", "Bcell", "MIBI", 1000 + i, spec[0], spec[0], (5, 5))
+            for i, spec in enumerate(fov_specs)
+        )
+
+        train_idx, val_idx = create_fov_splits(
+            ds, train_ratio=0.5, seed=0, stratify_by=("modality", "tissue"),
+            group_by_patient=False,
+        )
+        train_fovs = {ds.indices[i][5] for i in train_idx}
+        val_fovs = {ds.indices[i][5] for i in val_idx}
+        train_patients = {parse_patient_id((f, f)) for f in train_fovs}
+        val_patients = {parse_patient_id((f, f)) for f in val_fovs}
+
+        # With 8 patients x 2 FOVs shuffled per-FOV (not per-patient) at
+        # seed=0, at least one patient should straddle the split — this
+        # pins the pre-fix behavior so the "off" path is verified distinct
+        # from the "on" path above, not just structurally identical code.
+        assert train_patients & val_patients


### PR DESCRIPTION
Syncs `vanvalenlab:master` with the 12 commits that have accumulated on the fork since the v0.1.0 monorepo merge (#41). Focus is usability, packaging, correctness hardening, and test coverage — no changes to the core model architecture.

## Usability & packaging
- `feat(usability)`: CPU fallback note, public marker/cell-type listing API, `.dockerignore`
- `docs(readme)`: auto-select inference device instead of hardcoding `cuda:0`
- `fix(api)`: address usability review findings

## Correctness / robustness
- `fix(predict)`: validate raw/mask shapes and require canonical channels
- `fix(train)`: preserve `--resume_path` OneCycle schedule on longer `--epochs`; add optional patient-level split grouping
- `fix(baselines)`: gate Nimbus FOV-loading loop on dataset coverage loss
- `refactor(abstention)`: make `compute_iqr_fence` a private helper

## Model registry
- `chore(models)`: default registry to vocab-bundled 2026-06-15 resMLP (+ 2026-06-23 SSL arm)
- `chore(models)`: refresh baseline registry to 2026-06-30 retrains; drop re-hosted nimbus

## Tests & docs
- New coverage: `gold_metadata`, `predict` CLI `main()`, dataset/dataloader integration, resume/OneCycle schedule, patient-level split grouping, canonical inference, public listing API, Nimbus coverage gate
- Docs: sync GH Pages tutorial / API-key pages with master

Diffstat: 28 files, +1584 / −84 (mostly new tests).
