### PR TITLE
Prepare user workflows and runtime contracts for release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,7 @@
 # The optional-dependency names mirror [project.optional-dependencies] in
 # pyproject.toml. Leave DCT_EXTRAS empty for the inference-only image.
 
-# Base image must ship Python >=3.11 to satisfy this package's
-# `requires-python = ">=3.11"` floor (pyproject.toml). The previous
-# `pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime` tag ships Python 3.10.14, so
-# `pip install .` failed for EVERY profile with
-# "requires a different Python: 3.10.14 not in '>=3.11'". The 2.4.1 runtime tag
-# below bundles Python 3.11, clearing the floor (and bumps cuDNN 8 -> 9).
+# The base image supplies Python 3.11, matching the package's supported floor.
 FROM pytorch/pytorch:2.4.1-cuda12.1-cudnn9-runtime
 
 # Which optional-dependency set to install (e.g. "[train]", "[baselines]",
@@ -39,6 +34,5 @@ WORKDIR /app
 COPY . .
 
 # Install the package itself (plus any requested extras) from pyproject.toml.
-# The legacy requirements.txt / deepcelltypes-kit/ install steps are gone —
-# dependencies are declared in pyproject.toml now.
+# Dependencies are declared in pyproject.toml.
 RUN python -m pip install --no-cache-dir ".${DCT_EXTRAS}"

--- a/README.md
+++ b/README.md
@@ -59,20 +59,42 @@ required**. The marker / cell-type registry ships inside the package as a
 automatically:
 
 ```python
+import numpy as np
 import torch
 
-from deepcell_types import predict
+from deepcell_types import PredictionResult, predict
+from deepcell_types.utils import download_model
 
 # Pick a device: the default GPU if one is available, otherwise the CPU
 # (inference works the same on CPU, just slower). Use "cuda:1", "cuda:2",
 # etc. to target a specific GPU.
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
-# raw: numpy (C, H, W); mask: 2D label image; channel_names: list[str]
+# Minimal two-cell, two-marker example. Replace these arrays with your image
+# (C, H, W), integer instance mask (H, W), marker names, and image resolution.
+raw = np.zeros((2, 64, 64), dtype=np.float32)
+raw[0, 8:28, 8:28] = 100.0
+raw[1, 36:56, 36:56] = 100.0
+mask = np.zeros((64, 64), dtype=np.uint32)
+mask[8:28, 8:28] = 1
+mask[36:56, 36:56] = 2
+channel_names = ["CD3", "CD20"]
+mpp = 0.5
+model_path = download_model()
+
 # Pass the path returned by download_model() straight through to predict();
 # predict() also accepts a filesystem path to a .pt file directly.
-labels = predict(raw, mask, channel_names, mpp,
-                 model_name=model_path, device=device)
+result = predict(
+    raw,
+    mask,
+    channel_names,
+    mpp,
+    model_name=model_path,
+    device=device,
+    return_probabilities=True,
+)
+assert isinstance(result, PredictionResult)
+print(dict(zip(result.cell_indices.tolist(), result.cell_types)))
 ```
 
 For a complete example of the cell-type inference pipeline, check out
@@ -80,11 +102,14 @@ the [tutorial](https://vanvalenlab.github.io/deepcell-types/site/tutorial.html).
 
 ## TissueNet zarr archive (optional)
 
-The archive is **only** needed if you want to override the packaged
-registry — e.g. to run against a custom marker panel — or for training (see
-[Training](#training)). When present, `predict` reads the registry from it
-instead of `vocab.json`; pass `zarr_path=...` directly or set the
-`DEEPCELL_TYPES_ZARR_PATH` environment variable.
+The archive is **only** needed for training or to supply a registry that exactly
+matches a compatible checkpoint. Input panels may use any subset of the
+packaged markers, and acquisition-name aliases can be added to
+`channel_mapping.yaml`; neither case requires an archive. Adding, removing, or
+reordering model markers changes the model vocabulary and requires new marker
+embeddings plus a checkpoint trained for that exact registry. When an archive
+is present, `predict` reads its registry instead of `vocab.json`; pass
+`zarr_path=...` directly or set `DEEPCELL_TYPES_ZARR_PATH`.
 
 A registered user can download a public TissueNet zarr archive from
 `https://users.deepcell.org`; see `docs/site/API-key.md` for the access
@@ -116,15 +141,8 @@ When a single FOV's predictions look biologically implausible — usually becaus
 one channel is saturated or has heavy background and is steering the calls — the
 fix is to adapt the per-channel normalization for that FOV.
 
-**Start with the `preproc-adapt` skill** (`skills/preproc-adapt/`). It is the
-recommended, first-and-foremost way to do this: an agent-driven loop that
-inspects the panel, predicts, checks the cell-type composition against tissue
-biology, diagnoses *which* channel/op is the problem, and iterates the config for
-you — so you don't have to guess the ops by hand. Use it before hand-tuning.
-
-Under the hood the skill drives `predict`'s optional `preprocess` hook, which you
-can also call directly if you already know the fix. Build one declaratively from a
-bounded set of ops:
+Use `predict`'s optional `preprocess` hook to apply a declarative, reviewable
+sequence of bounded operations:
 
 ```python
 import torch
@@ -138,7 +156,7 @@ config = [
     {"op": "channel_drop", "names": ["NeuN"]},  # drop a confounding marker
     {"op": "min_max_normalize"},                # model sees [0, 1]
 ]
-labels = predict(raw, mask, channel_names, mpp, model_name=...,
+labels = predict(raw, mask, channel_names, mpp, model_name=model_path,
                  device=device, preprocess=make_preprocessor(config))
 ```
 
@@ -147,13 +165,21 @@ resolved marker names, and must return a `(C, H, W)` array in `[0, 1]`. With
 `preprocess=None` (default) the built-in p99.9 clip + min-max is used;
 `make_preprocessor(DEFAULT_CONFIG)` reproduces that default exactly.
 
+Repository contributors who use a compatible coding agent may optionally use
+the [`preproc-adapt` skill](skills/preproc-adapt/) to inspect prediction results
+and iterate on this configuration. The Python API above remains the supported
+and tool-independent interface.
+
 ## Training
 
-To retrain or fine-tune, install the `[train]` extra (pulls in `zarr`,
-`pandas`, `scikit-learn`, `torchmetrics`, plotly, etc.):
+Training and archive evaluation are source-checkout workflows; their scripts
+are not installed by the wheel. Clone the repository and install its training
+environment from the repository root:
 
 ```bash
-pip install "deepcell-types[train] @ git+https://github.com/vanvalenlab/deepcell-types@master"
+git clone https://github.com/vanvalenlab/deepcell-types.git
+cd deepcell-types
+uv sync --extra train
 ```
 
 Training entry points live under `scripts/`:
@@ -165,12 +191,10 @@ Training entry points live under `scripts/`:
   auto-detected from the checkpoint at inference (no flag to set).
 - `scripts/pretrain.py` — masked-marker pretraining.
 - `scripts/predict.py` — batched evaluation over a zarr archive.
-- `scripts/evaluate_on_test.sh` — **canonical evaluation on the held-out 129-FOV
-  test split** (`splits/fov_split_test_current.json`). All headline cell-type numbers
-  are reported on this frozen, leakage-free test set; this is the default eval. On
-  this split the two-stage resMLP recipe reaches **80.27 hierarchical macro-F1**
-  (full-coverage, no abstention), ahead of a tuned XGBoost baseline (79.03) and the
-  other paper baselines.
+- `scripts/evaluate_on_test.sh` — evaluation on the held-out 129-FOV test split
+  (`splits/fov_split_test_current.json`). See the cited paper for reported
+  results; this repository does not currently include the prediction artifacts
+  needed to independently verify its headline values.
 
 All training scripts read configuration from a TissueNet zarr v3 archive.
 Pass `--zarr_dir` (training scripts) or set `DEEPCELL_TYPES_ZARR_PATH`
@@ -178,6 +202,41 @@ Pass `--zarr_dir` (training scripts) or set `DEEPCELL_TYPES_ZARR_PATH`
 modules under `deepcell_types.training` (e.g. `TissueNetConfig`,
 `FullImageDataset`, `FocalLoss`, `HierarchicalLoss`) are stable enough to
 import directly for custom training scripts.
+
+From the repository root, a minimal smoke run and the two-stage training recipe
+look like this (replace the archive and embedding paths with downloaded assets):
+
+```bash
+uv run python scripts/pretrain.py \
+  --zarr_dir /data/tissuenet.zarr \
+  --svd_embeddings_path /data/svd_512.npz \
+  --split_file splits/fov_split.json \
+  --model_name pretrain
+
+uv run python scripts/train.py \
+  --zarr_dir /data/tissuenet.zarr \
+  --svd_embeddings_path /data/svd_512.npz \
+  --split_file splits/fov_split.json \
+  --model_name smoke --epochs 1 --max_samples_per_epoch 256 \
+  --max_val_samples 128 --batch_size 16 --num_workers 0
+
+uv run python scripts/train.py \
+  --zarr_dir /data/tissuenet.zarr \
+  --svd_embeddings_path /data/svd_512.npz \
+  --split_file splits/fov_split.json \
+  --model_name stage1
+
+uv run python scripts/retrain_head.py \
+  --zarr_dir /data/tissuenet.zarr \
+  --svd_embeddings_path /data/svd_512.npz \
+  --split_file splits/fov_split.json \
+  --pretrained_path models/model_stage1_best.pt \
+  --output models/model_stage2_resmlp_best.pt
+```
+
+The scripts write checkpoints under `models/` and validation predictions under
+`output/`. Full training is GPU-oriented; use `--device_num cpu` only for small
+smoke runs. Run any script with `--help` for resource-control options.
 
 ## Baselines
 
@@ -200,17 +259,28 @@ No submodules are required.
 - **XGBoost** — XGBoost on mean-marker-intensity features.
 
   ```bash
-  pip install -e ".[baseline-xgboost]"
-  python -m deepcell_types.baselines xgboost ...
-  python -m deepcell_types.baselines xgboost-tune ...
+  uv sync --extra baseline-xgboost
+  uv run python -m deepcell_types.baselines xgboost \
+    --zarr_dir /data/tissuenet.zarr \
+    --split_file splits/fov_split_test_current.json \
+    --val_split_file splits/fov_split_valsubset.json \
+    --features_cache output/xgboost_features.npz
+  uv run python -m deepcell_types.baselines xgboost-tune \
+    --zarr_dir /data/tissuenet.zarr \
+    --split_file splits/fov_split_test_current.json \
+    --val_split_file splits/fov_split_valsubset.json \
+    --features_cache output/xgboost_features.npz \
+    --storage sqlite:///output/xgboost_tuning.db --n_trials 50
   ```
 
 - **Nimbus** — Nimbus UNet marker-positivity baseline
   ([Rumberger et al., *Nature Methods* 2025](https://doi.org/10.1038/s41592-025-02826-9)).
 
   ```bash
-  pip install -e ".[baseline-nimbus]"
-  python -m deepcell_types.baselines nimbus ...
+  uv sync --extra baseline-nimbus
+  uv run python -m deepcell_types.baselines nimbus \
+    --zarr_dir /data/tissuenet.zarr \
+    --checkpoint latest --batch_size 8
   ```
 
   > **Note:** `baseline-nimbus` pins `nimbus-inference==0.0.5`, which
@@ -220,8 +290,12 @@ No submodules are required.
   ([*Nature Communications* 2023](https://doi.org/10.1038/s41467-023-44188-w)).
 
   ```bash
-  pip install -e ".[baseline-maps]"
-  python -m deepcell_types.baselines maps ...
+  uv sync --extra baseline-maps
+  uv run python -m deepcell_types.baselines maps \
+    --zarr_dir /data/tissuenet.zarr \
+    --split_file splits/fov_split_test_current.json \
+    --val_split_file splits/fov_split_valsubset.json \
+    --features_cache output/maps_features.npz
   ```
 
 - **CellSighter** — ResNet-50 multiplexed cell classifier
@@ -229,8 +303,12 @@ No submodules are required.
   Pulls in `torchvision`.
 
   ```bash
-  pip install -e ".[baseline-cellsighter]"
-  python -m deepcell_types.baselines cellsighter ...
+  uv sync --extra baseline-cellsighter
+  uv run python -m deepcell_types.baselines cellsighter \
+    --zarr_dir /data/tissuenet.zarr \
+    --split_file splits/fov_split.json \
+    --val_split_file splits/fov_split_valsubset.json \
+    --test_split_file splits/fov_split_test_current.json
   ```
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ export DEEPCELL_TYPES_ZARR_PATH=/absolute/path/to/tissuenet.zarr
 ### Validating an archive before publishing
 
 The archive's `all_standardized_channels` attribute *is* the model's
-marker→index map, so it must match the order the released checkpoint and
-`embeddings/svd_512.npz` were built with — reordering or resizing it silently
-breaks inference. Before publishing an archive (or a checkpoint), run the
-release gate against the real archive and the released embeddings:
+marker→index map, so it must match the order the released checkpoint was built
+with — reordering or resizing it silently breaks inference. Before publishing
+an archive (or a checkpoint), run the release gate against the real archive and
+the released marker order (a JSON file listing the expected channel order):
 
 ```bash
-scripts/check_release_archive.sh /path/to/tissuenet.zarr /path/to/svd_512.npz
+scripts/check_release_archive.sh /path/to/tissuenet.zarr /path/to/marker_order.json
 ```
 
 It exits non-zero on any marker-order/size drift. (The check's logic is

--- a/deepcell_types/baselines/cellsighter/run.py
+++ b/deepcell_types/baselines/cellsighter/run.py
@@ -715,17 +715,17 @@ def main(
         cifar_stem=cifar_stem,
     ).to(device)
 
-    # Fix 6: torch.compile for fused operations (PyTorch 2.x+)
+    # Compile supported operations for the fused PyTorch execution path.
     if not no_compile and hasattr(torch, "compile"):
         print("Applying torch.compile...")
         model = torch.compile(model)
 
-    # Fix 1: Mixed precision (AMP)
+    # Mixed precision (AMP).
     use_amp = use_cuda and not no_amp
     scaler = torch.amp.GradScaler("cuda") if use_amp else None
     amp_dtype = torch.float16 if use_amp else None
 
-    # Fix 5: Move label_remap to device once (avoid per-batch CPU→GPU transfer)
+    # Move label_remap to the device once to avoid per-batch transfers.
     label_remap = label_remap.to(device)
 
     # Loss and optimizer (matching CellSighter paper: constant lr=0.001)

--- a/deepcell_types/baselines/cellsighter/run.py
+++ b/deepcell_types/baselines/cellsighter/run.py
@@ -677,9 +677,7 @@ def main(
         with open(split_file) as _f:
             _sj = _json.load(_f)
         _kept = set(keep_datasets) if keep_datasets else None
-        _train_fovs = [
-            k for k in _sj["train"] if (_kept is None or k in _kept)
-        ]
+        _train_fovs = [k for k in _sj["train"] if (_kept is None or k in _kept)]
         print(f"Active datasets: {metadata['active_datasets']}")
         print(f"Number of samples: {metadata['num_samples']}")
         print(
@@ -702,8 +700,7 @@ def main(
         print(f"Active datasets: {metadata['active_datasets']}")
         print(f"Number of samples: {metadata['num_samples']}")
         print(
-            f"Inner-val cells (FOV-grouped, for selection): "
-            f"{metadata['num_inner_val']}"
+            f"Inner-val cells (FOV-grouped, for selection): {metadata['num_inner_val']}"
         )
 
     # Create model

--- a/deepcell_types/baselines/maps/run.py
+++ b/deepcell_types/baselines/maps/run.py
@@ -150,7 +150,8 @@ def evaluate(
     y: np.ndarray,
     device: torch.device,
     batch_size: int = 1024,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    criterion=None,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray] | Tuple[np.ndarray, np.ndarray, np.ndarray, float]:
     """
     Evaluate model on dataset.
 
@@ -168,16 +169,22 @@ def evaluate(
     """
     model.eval()
     all_prob = []
+    total_loss = 0.0
 
     # Process in batches
     for i in range(0, len(X), batch_size):
         X_batch = X[i : i + batch_size].to(device)
-        _, probs = model(X_batch)  # Use probs for evaluation
+        logits, probs = model(X_batch)
         all_prob.append(probs.cpu().numpy())
+        if criterion is not None:
+            y_batch = torch.from_numpy(y[i : i + batch_size].astype(np.int64)).to(device)
+            total_loss += criterion(logits, y_batch).item() * len(y_batch)
 
     y_prob = np.concatenate(all_prob, axis=0)
     y_pred = y_prob.argmax(axis=1)
 
+    if criterion is not None:
+        return y, y_pred, y_prob, total_loss / len(y)
     return y, y_pred, y_prob
 
 
@@ -590,8 +597,8 @@ def main(
         # Evaluate on the inner-val set (selection signal only — never the
         # reported test set). Shared hierarchy collapse (Tcell + Stromal)
         # matches the main model's LossesAndMetrics.compute() exactly.
-        y_true, y_pred, y_prob = evaluate(
-            model, X_inner_val_tensor, y_inner_val, device
+        y_true, y_pred, y_prob, val_loss = evaluate(
+            model, X_inner_val_tensor, y_inner_val, device, criterion=criterion
         )
         metrics = compute_baseline_metrics(
             y_true,
@@ -614,14 +621,6 @@ def main(
             )
         except ValueError:
             metrics["auroc"] = float("nan")
-
-        # Compute inner-validation loss (drives checkpoint selection)
-        model.eval()
-        with torch.no_grad():
-            X_inner_val_dev = X_inner_val_tensor.to(device)
-            y_inner_val_dev = torch.from_numpy(y_inner_val.astype(np.int64)).to(device)
-            val_logits, _ = model(X_inner_val_dev)
-            val_loss = criterion(val_logits, y_inner_val_dev).item()
 
         # Canonical selection signal: metrics["macro_f1"] is the hierarchical
         # ct_macro_f1 on the selection-val set (the same reduction the main

--- a/deepcell_types/baselines/maps/run.py
+++ b/deepcell_types/baselines/maps/run.py
@@ -151,7 +151,10 @@ def evaluate(
     device: torch.device,
     batch_size: int = 1024,
     criterion=None,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray] | Tuple[np.ndarray, np.ndarray, np.ndarray, float]:
+) -> (
+    Tuple[np.ndarray, np.ndarray, np.ndarray]
+    | Tuple[np.ndarray, np.ndarray, np.ndarray, float]
+):
     """
     Evaluate model on dataset.
 
@@ -177,7 +180,9 @@ def evaluate(
         logits, probs = model(X_batch)
         all_prob.append(probs.cpu().numpy())
         if criterion is not None:
-            y_batch = torch.from_numpy(y[i : i + batch_size].astype(np.int64)).to(device)
+            y_batch = torch.from_numpy(y[i : i + batch_size].astype(np.int64)).to(
+                device
+            )
             total_loss += criterion(logits, y_batch).item() * len(y_batch)
 
     y_prob = np.concatenate(all_prob, axis=0)
@@ -474,7 +479,10 @@ def main(
         inner_train_idx, inner_val_idx = next(
             gss.split(X_train, y_train, groups=train_fov_array)
         )
-        X_inner_train, y_inner_train = X_train[inner_train_idx], y_train[inner_train_idx]
+        X_inner_train, y_inner_train = (
+            X_train[inner_train_idx],
+            y_train[inner_train_idx],
+        )
         X_inner_val, y_inner_val = X_train[inner_val_idx], y_train[inner_val_idx]
         select_on_macro_f1 = False
         print(

--- a/deepcell_types/baselines/nimbus/run.py
+++ b/deepcell_types/baselines/nimbus/run.py
@@ -166,6 +166,18 @@ def check_dataset_coverage(
         )
 
 
+def combine_predictions(all_predictions: List[pd.DataFrame]) -> pd.DataFrame:
+    """Concatenate per-FOV prediction frames, failing if none were produced.
+
+    A run that generates no predictions must fail loudly rather than write an
+    empty result and report success (baselines are scored at full coverage).
+    Extracted from ``main()`` so the zero-prediction contract is unit-testable.
+    """
+    if len(all_predictions) == 0:
+        raise click.ClickException("No predictions were generated.")
+    return pd.concat(all_predictions, ignore_index=True)
+
+
 def compute_marker_positivity_metrics(
     predictions: pd.DataFrame,
     ground_truth: Dict[str, pd.DataFrame],
@@ -643,11 +655,8 @@ def main(
     # dataset_keys list, since --max_fovs can end the loop early.
     check_dataset_coverage(skipped_dataset_keys, fov_count + len(skipped_dataset_keys))
 
-    # Combine all predictions
-    if len(all_predictions) == 0:
-        raise click.ClickException("No predictions were generated.")
-
-    predictions_df = pd.concat(all_predictions, ignore_index=True)
+    # Combine all predictions (fails loudly if the run produced none)
+    predictions_df = combine_predictions(all_predictions)
     print(f"\nGenerated predictions for {len(predictions_df)} cells")
 
     # Compute metrics

--- a/deepcell_types/baselines/nimbus/run.py
+++ b/deepcell_types/baselines/nimbus/run.py
@@ -645,8 +645,7 @@ def main(
 
     # Combine all predictions
     if len(all_predictions) == 0:
-        print("Error: No predictions generated.")
-        return
+        raise click.ClickException("No predictions were generated.")
 
     predictions_df = pd.concat(all_predictions, ignore_index=True)
     print(f"\nGenerated predictions for {len(predictions_df)} cells")

--- a/deepcell_types/baselines/xgb/tuning.py
+++ b/deepcell_types/baselines/xgb/tuning.py
@@ -452,6 +452,7 @@ def _run_canonical_val_tuning(
     model_name=None,
     features_cache=None,
     class_balance="dct",
+    metric="macro_f1",
 ):
     """Canonical external-val tuning protocol (mirrors the main DCT model).
 
@@ -581,7 +582,7 @@ def _run_canonical_val_tuning(
         y_sel,
         num_classes=n_classes_compact,
         n_trials=n_trials,
-        metric="macro_f1",
+        metric=metric,
         study_name=study_name,
         storage=storage,
         hierarchy=CELL_TYPE_HIERARCHY,
@@ -867,6 +868,7 @@ def main(
             train_fov_names_full=train_fov_names_full,
             num_classes=num_classes,
             n_trials=n_trials,
+            metric=metric,
             study_name=study_name,
             storage=storage,
             device_num=device_num,

--- a/deepcell_types/baselines/xgb/tuning.py
+++ b/deepcell_types/baselines/xgb/tuning.py
@@ -631,8 +631,8 @@ def _run_canonical_val_tuning(
             {
                 "best_params": best_params,
                 "best_value": study.best_trial.value,
-                "metric": "macro_f1",
-                "selection": "canonical external ct_macro_f1 (capped 200k val)",
+                "metric": metric,
+                "selection": f"canonical external ct_{metric} (capped 200k val)",
                 "n_trials": n_trials,
                 "test_metrics": {
                     "macro_accuracy": test_metrics["macro_accuracy"],

--- a/deepcell_types/config.py
+++ b/deepcell_types/config.py
@@ -37,6 +37,7 @@ def _resolve_archive_path(explicit_path):
     so the caller falls back to the packaged vocabulary snapshot (archive-free
     inference).
     """
+    env_path = os.environ.get(DCTConfig.ARCHIVE_ENV_VAR)
     for candidate in _archive_candidate_paths(explicit_path):
         if (candidate / "zarr.json").exists():
             return candidate
@@ -44,6 +45,11 @@ def _resolve_archive_path(explicit_path):
         raise FileNotFoundError(
             f"No TissueNet zarr archive found at {explicit_path} "
             "(expected a 'zarr.json' there)."
+        )
+    if env_path:
+        raise FileNotFoundError(
+            f"{DCTConfig.ARCHIVE_ENV_VAR} points to {env_path}, but no TissueNet "
+            "zarr archive was found there (expected a 'zarr.json' file)."
         )
     return None
 

--- a/deepcell_types/config.py
+++ b/deepcell_types/config.py
@@ -251,6 +251,14 @@ class DCTConfig:
             cell_type_mapping = vocab["cell_type_mapping"]
             all_channels = vocab["all_standardized_channels"]
             domains = list(vocab.get("domains", []))
+            if not cell_type_mapping:
+                raise ValueError(
+                    "Packaged vocab.json is missing cell_type_mapping."
+                )
+            if not all_channels:
+                raise ValueError(
+                    "Packaged vocab.json is missing all_standardized_channels."
+                )
 
         self._ct2idx = {str(ct): int(idx) for ct, idx in cell_type_mapping.items()}
         expected_indices = set(range(len(self._ct2idx)))

--- a/deepcell_types/config.py
+++ b/deepcell_types/config.py
@@ -1,7 +1,7 @@
 import json
 import os
-from functools import lru_cache
 from pathlib import Path
+from types import MappingProxyType
 
 import numpy as np
 import yaml
@@ -73,12 +73,6 @@ def _load_packaged_vocab():
     return _read_json(vocab_path)
 
 
-# These metadata readers are cached unbounded by path string. They assume the
-# archive is immutable for the lifetime of the process — a second DCTConfig over
-# the same path after the archive changed on disk returns the cached (stale)
-# result. Inference processes are short-lived and archives are published
-# read-only, so this holds in practice.
-@lru_cache(maxsize=None)
 def _archive_root_attrs(zarr_path_str):
     zarr_path = Path(zarr_path_str)
     root_meta = _read_json(zarr_path / "zarr.json")
@@ -89,7 +83,6 @@ def _iter_fov_metadata_paths(zarr_path):
     return sorted(zarr_path.glob("*/*/*/*/*/zarr.json"))
 
 
-@lru_cache(maxsize=None)
 def _archive_domains(zarr_path_str):
     zarr_path = Path(zarr_path_str)
     domains = set()
@@ -151,7 +144,6 @@ def _read_v3_1d_array(array_dir):
     return out
 
 
-@lru_cache(maxsize=None)
 def _archive_tissue_celltype_mapping(zarr_path_str):
     zarr_path = Path(zarr_path_str)
     mapping = {}
@@ -261,7 +253,15 @@ class DCTConfig:
             domains = list(vocab.get("domains", []))
 
         self._ct2idx = {str(ct): int(idx) for ct, idx in cell_type_mapping.items()}
+        expected_indices = set(range(len(self._ct2idx)))
+        if set(self._ct2idx.values()) != expected_indices:
+            raise ValueError(
+                "cell_type_mapping indices must be unique and contiguous from 0 "
+                f"to {len(self._ct2idx) - 1}; got {self._ct2idx}."
+            )
         self._master_channels = [str(ch) for ch in all_channels]
+        if len(set(self._master_channels)) != len(self._master_channels):
+            raise ValueError("all_standardized_channels must contain unique names.")
         self._marker2idx = {ch: idx for idx, ch in enumerate(self.master_channels)}
 
         self._domain2idx = {domain: idx for idx, domain in enumerate(domains)}
@@ -318,19 +318,19 @@ class DCTConfig:
 
     @property
     def ct2idx(self):
-        return self._ct2idx
+        return MappingProxyType(self._ct2idx)
 
     @property
     def domain2idx(self):
-        return self._domain2idx
+        return MappingProxyType(self._domain2idx)
 
     @property
     def marker2idx(self):
-        return self._marker2idx
+        return MappingProxyType(self._marker2idx)
 
     @property
     def master_channels(self):
-        return self._master_channels
+        return tuple(self._master_channels)
 
     def get_tct_mapping(self):
         if self.zarr_path is None:

--- a/deepcell_types/predict.py
+++ b/deepcell_types/predict.py
@@ -17,6 +17,7 @@ __all__ = ["predict", "PredictionResult"]
 # (torch is a ~1.4s import). Keep it that way — do not add a top-level
 # `import torch` here.
 
+
 def _names_ordered_by_index(mapping):
     return [name for name, _ in sorted(mapping.items(), key=lambda item: int(item[1]))]
 
@@ -71,6 +72,24 @@ def validate_checkpoint_vocabulary(checkpoint, ct2idx, marker2idx):
             "Checkpoint marker ordering (canonical_channels) does not match the "
             "inference vocabulary's marker2idx ordering."
         )
+
+
+def validate_checkpoint_architecture_config(checkpoint):
+    """Return architecture fields that cannot be inferred from checkpoint tensors."""
+    config = checkpoint.get("config", {}) if isinstance(checkpoint, dict) else {}
+    missing = [key for key in ("n_heads", "compat_marker0_zero") if key not in config]
+    if missing:
+        raise ValueError(
+            f"Checkpoint config is missing {', '.join(missing)}. These fields "
+            "cannot be recovered from checkpoint weights."
+        )
+    n_heads = config["n_heads"]
+    if isinstance(n_heads, bool) or not isinstance(n_heads, int) or n_heads <= 0:
+        raise ValueError("Checkpoint config n_heads must be a positive integer.")
+    compat = config["compat_marker0_zero"]
+    if not isinstance(compat, bool):
+        raise ValueError("Checkpoint config compat_marker0_zero must be a boolean.")
+    return n_heads, compat
 
 
 @dataclass(frozen=True)
@@ -261,8 +280,6 @@ def _build_model(checkpoint, dct_config, device):
     from .model import create_model
 
     state_dict = _state_dict(checkpoint)
-    config = checkpoint.get("config", {}) if isinstance(checkpoint, dict) else {}
-
     try:
         marker_weight = state_dict["marker_embedder.embed_layer.weight"]
         n_markers = marker_weight.shape[0] - 1
@@ -302,18 +319,7 @@ def _build_model(checkpoint, dct_config, device):
     # is a pure-Python numerics flag), so they must be recorded in the checkpoint
     # config. scripts/train.py and retrain_head.py bundle both; a wrong value
     # loads with silently wrong numerics, so require them rather than guess.
-    missing_arch_keys = [
-        k for k in ("n_heads", "compat_marker0_zero") if k not in config
-    ]
-    if missing_arch_keys:
-        raise ValueError(
-            f"Checkpoint config is missing {', '.join(missing_arch_keys)}. These "
-            "are not recoverable from the weights and a wrong value loads with "
-            "silently wrong numerics; scripts/train.py records them in every "
-            "checkpoint."
-        )
-    n_heads = int(config["n_heads"])
-    compat_marker0_zero = bool(config["compat_marker0_zero"])
+    n_heads, compat_marker0_zero = validate_checkpoint_architecture_config(checkpoint)
 
     model = create_model(
         dct_config,

--- a/deepcell_types/preprocessing.py
+++ b/deepcell_types/preprocessing.py
@@ -219,8 +219,12 @@ def preprocess_fov(
         raise ValueError(
             f"len(channel_names)={len(channel_names)} != raw.shape[0]={raw.shape[0]}"
         )
-    if native_mpp <= 0.0:
-        raise ValueError(f"native_mpp must be positive, got {native_mpp}")
+    if not np.isfinite(native_mpp) or native_mpp <= 0.0:
+        raise ValueError(f"native_mpp must be positive and finite, got {native_mpp}")
+    if not np.isfinite(target_mpp) or target_mpp <= 0.0:
+        raise ValueError(f"target_mpp must be positive and finite, got {target_mpp}")
+    if not np.isfinite(percentile) or not 0.0 <= percentile <= 100.0:
+        raise ValueError(f"percentile must be finite and in [0, 100], got {percentile}")
 
     scale = native_mpp / target_mpp
     raw_chw, mask_r = _resample(raw, mask, scale)

--- a/deepcell_types/preprocessing.py
+++ b/deepcell_types/preprocessing.py
@@ -10,10 +10,8 @@ training pipeline consumes from ``preprocessed/raw`` + ``preprocessed/mask``:
 3. **Per-channel min-max normalize** to ``[0, 1]``.
 4. Cast mask to ``uint32``; compute centroids in resampled coordinates.
 
-This recipe was recovered from
-the archive ingestion pipeline —
-the script that originally produced the production archive's
-``preprocessed/raw`` arrays. A snapshot test
+This recipe matches the archive ingestion pipeline that produces the
+production archive's ``preprocessed/raw`` arrays. A snapshot test
 (``tests/test_preprocessing.py::test_snapshot_against_production``)
 confirms it reproduces production output within sub-pixel resampling
 noise (max per-channel mean drift ~0.05 on
@@ -26,13 +24,12 @@ itself being fixed.
 
 ## Public API
 
-- ``preprocess_fov(raw, mask, native_mpp, channel_names) → PreprocessedFov``
+- ``preprocess_fov(raw, mask, *, native_mpp=..., channel_names=...) → PreprocessedFov``
 - ``DEFAULT_PERCENTILE = 99.9``
 - ``TARGET_MPP = 0.5``
 
 The function is deterministic given the input — equal inputs produce
-bit-equal outputs (modulo float precision noise from skimage.rescale,
-which is the same noise present in the historical pipeline).
+bit-equal outputs (modulo float precision noise from skimage.rescale).
 """
 
 from __future__ import annotations

--- a/deepcell_types/preprocessing_ops.py
+++ b/deepcell_types/preprocessing_ops.py
@@ -92,6 +92,15 @@ def apply_config(raw, channel_names, config):
     """
     x = np.asarray(raw, dtype=np.float32).copy()
     idx = {n: i for i, n in enumerate(channel_names)}
+
+    def require_known(names):
+        unknown = sorted(set(names) - set(idx))
+        if unknown:
+            raise ValueError(
+                f"unknown preprocessing channel name(s): {unknown}; "
+                f"available channels: {sorted(idx)}"
+            )
+
     for step in config:
         op = step["op"]
         if op == "clip_percentile":
@@ -102,7 +111,9 @@ def apply_config(raw, channel_names, config):
             x = np.clip(x - float(step["value"]), 0, None)
         elif op == "background_subtract_per_channel":
             names = step.get("names")
-            sel = [idx[n] for n in names if n in idx] if names else None
+            if names:
+                require_known(names)
+            sel = [idx[n] for n in names] if names else None
             x = _background_subtract_per_channel(x, float(step.get("p", 25.0)), sel)
         elif op == "gamma":
             mx = x.max(axis=(1, 2), keepdims=True)
@@ -121,13 +132,13 @@ def apply_config(raw, channel_names, config):
         elif op == "hot_pixel_removal":
             x = _hot_pixel_removal(x, float(step.get("z", 5.0)))
         elif op == "channel_drop":
+            require_known(step["names"])
             for n in step["names"]:
-                if n in idx:
-                    x[idx[n]] = 0.0
+                x[idx[n]] = 0.0
         elif op == "channel_weight":
+            require_known(step["weights"])
             for n, w in step["weights"].items():
-                if n in idx:
-                    x[idx[n]] *= float(w)
+                x[idx[n]] *= float(w)
         elif op == "min_max_normalize":
             x = _min_max(x)
         else:

--- a/deepcell_types/training/config.py
+++ b/deepcell_types/training/config.py
@@ -44,7 +44,6 @@ CONFIG_DIR = Path(__file__).parent / "config"
 WARMUP_PCT = 0.05  # Warmup percentage for OneCycleLR scheduler
 
 
-
 class TissueNetConfig:
     """
     Configuration loaded from TissueNet zarr archive.
@@ -274,7 +273,12 @@ class TissueNetConfig:
             # try/except is needed around it.
             mp_json_path = f"{zarr_dir_str}/{key}/marker_positivity/zarr.json"
             result["has_mp"] = os.path.exists(mp_json_path)
-        except (FileNotFoundError, OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
+        except (
+            FileNotFoundError,
+            OSError,
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+        ) as e:
             logger.warning("_read_dataset_metadata failed for %s: %s", key, e)
         return result
 
@@ -646,7 +650,9 @@ class TissueNetConfig:
                 "Failed to read marker_positivity attrs for %s (%s: %s); "
                 "MP signal will be unavailable for this dataset. Likely an "
                 "archive schema drift — rerun the archive-ingestion pipeline.",
-                dataset_key, type(e).__name__, e,
+                dataset_key,
+                type(e).__name__,
+                e,
                 exc_info=True,
             )
             return None
@@ -665,7 +671,9 @@ class TissueNetConfig:
                     "marker_positivity has %d row label(s) not in ct2idx (dead-code rows; "
                     "first seen in dataset %s): %s. Rerun the archive-ingestion "
                     "pipeline to repopulate the standardized labels.",
-                    len(new_rows), dataset_key, new_rows,
+                    len(new_rows),
+                    dataset_key,
+                    new_rows,
                 )
 
         try:
@@ -674,7 +682,8 @@ class TissueNetConfig:
             logger.warning(
                 "marker_positivity matrix for %s is malformed (%s); "
                 "MP signal disabled for this dataset.",
-                dataset_key, e,
+                dataset_key,
+                e,
                 exc_info=True,
             )
             return None
@@ -709,7 +718,9 @@ class TissueNetConfig:
             logger.warning(
                 "tissue attr read failed for %s (%s: %s) — tissue-aware "
                 "masking disabled for this dataset",
-                dataset_key, type(e).__name__, e,
+                dataset_key,
+                type(e).__name__,
+                e,
                 exc_info=True,
             )
             return None
@@ -719,7 +730,9 @@ class TissueNetConfig:
             logger.warning(
                 "tissue attr for %s has unexpected type %s (value=%r) — "
                 "tissue-aware masking disabled",
-                dataset_key, type(raw).__name__, raw,
+                dataset_key,
+                type(raw).__name__,
+                raw,
             )
             return None
         return self._normalize_tissue_name(raw)

--- a/deepcell_types/training/config.py
+++ b/deepcell_types/training/config.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 from pathlib import Path
+from types import MappingProxyType
 from typing import Dict, List, Optional
 
 import numpy as np
@@ -111,6 +112,12 @@ class TissueNetConfig:
         # Build ct2idx from cell_type_mapping (maps cell type name -> integer ID)
         # This is used for model output labels
         self._ct2idx = {ct: idx for ct, idx in self._cell_type_mapping.items()}
+        expected_indices = set(range(len(self._ct2idx)))
+        if set(self._ct2idx.values()) != expected_indices:
+            raise ValueError(
+                "cell_type_mapping indices must be unique and contiguous from 0 "
+                f"to {len(self._ct2idx) - 1}; got {self._ct2idx}."
+            )
 
         # Build marker2idx from all standardized channels
         self._marker2idx = {ch: idx for idx, ch in enumerate(self._all_channels)}
@@ -147,12 +154,12 @@ class TissueNetConfig:
     @property
     def ct2idx(self) -> Dict[str, int]:
         """Cell type name to integer index mapping."""
-        return self._ct2idx
+        return MappingProxyType(self._ct2idx)
 
     @property
     def marker2idx(self) -> Dict[str, int]:
         """Marker/channel name to integer index mapping."""
-        return self._marker2idx
+        return MappingProxyType(self._marker2idx)
 
     @property
     def tumor_datasets(self) -> set:
@@ -166,7 +173,7 @@ class TissueNetConfig:
             # Get unique domains from domain_mapping
             domains = sorted(set(self.domain_mapping.values()))
             self._domain2idx = {d: idx for idx, d in enumerate(domains)}
-        return self._domain2idx
+        return MappingProxyType(self._domain2idx)
 
     @property
     def NUM_DOMAINS(self) -> int:
@@ -725,4 +732,3 @@ from .patch import (  # noqa: F401, E402
     extract_patch,
     extract_patch_from_zarr,
 )
-

--- a/deepcell_types/training/config.py
+++ b/deepcell_types/training/config.py
@@ -108,6 +108,19 @@ class TissueNetConfig:
             self._zf.attrs.get("all_standardized_cell_types", [])
         )
 
+        # An archive missing these attrs (typo'd key, wrong/truncated write)
+        # defaults to empty above, which would pass the contiguity check below
+        # vacuously and yield NUM_CELLTYPES=0 — silently dropping every cell at
+        # training time. Reject it loudly instead.
+        if not self._cell_type_mapping:
+            raise ValueError(
+                f"{self.zarr_path} is missing root attrs.cell_type_mapping."
+            )
+        if not self._all_channels:
+            raise ValueError(
+                f"{self.zarr_path} is missing root attrs.all_standardized_channels."
+            )
+
         # Build ct2idx from cell_type_mapping (maps cell type name -> integer ID)
         # This is used for model output labels
         self._ct2idx = {ct: idx for ct, idx in self._cell_type_mapping.items()}

--- a/deepcell_types/training/dataset.py
+++ b/deepcell_types/training/dataset.py
@@ -417,30 +417,42 @@ class FullImageDataset(Dataset):
         # check + world-writable rejection blocks that vector while leaving the
         # single-user workflow unchanged.
         try:
-            st = cache_path.stat()
-        except OSError as e:
-            logger.warning("cell-data cache stat failed (%s), rebuilding...", e)
-            return None
-        if st.st_uid != os.getuid():
-            logger.warning(
-                "cell-data cache at %s not owned by current user (uid=%d, "
-                "expected %d) — rejecting and rebuilding",
-                cache_path,
-                st.st_uid,
-                os.getuid(),
-            )
-            return None
-        if st.st_mode & 0o002:  # world-writable
-            logger.warning(
-                "cell-data cache at %s is world-writable — rejecting and rebuilding",
-                cache_path,
-            )
-            return None
-        try:
-            with open(cache_path, "rb") as f:
+            flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+            fd = os.open(cache_path, flags)
+            with os.fdopen(fd, "rb") as f:
+                st = os.fstat(f.fileno())
+                if st.st_uid != os.getuid():
+                    logger.warning(
+                        "cell-data cache at %s not owned by current user "
+                        "(uid=%d, expected %d) — rejecting and rebuilding",
+                        cache_path,
+                        st.st_uid,
+                        os.getuid(),
+                    )
+                    return None
+                if st.st_mode & 0o022:
+                    logger.warning(
+                        "cell-data cache at %s is group- or world-writable — "
+                        "rejecting and rebuilding",
+                        cache_path,
+                    )
+                    return None
                 cached = pickle.load(f)
-        except (OSError, pickle.UnpicklingError, EOFError) as e:
-            logger.warning("cell-data cache load failed (%s), rebuilding...", e)
+        except (
+            OSError,
+            pickle.UnpicklingError,
+            EOFError,
+            AttributeError,
+            ImportError,
+            IndexError,
+            TypeError,
+            ValueError,
+        ) as e:
+            logger.warning(
+                "cell-data cache at %s could not be loaded (%s), rebuilding...",
+                cache_path,
+                e,
+            )
             return None
 
         # New format: {"fingerprint": ..., "data": {...}}

--- a/deepcell_types/training/dataset.py
+++ b/deepcell_types/training/dataset.py
@@ -343,13 +343,9 @@ class FullImageDataset(Dataset):
                     continue
                 domain = modality_attr
 
-            cell_types, cell_indices, centroids = entry["cell_data"]
-            lengths = (len(cell_types), len(cell_indices), len(centroids))
-            if len(set(lengths)) != 1:
-                raise ValueError(
-                    f"{dataset_key}: cell_type, cell_index, and centroid arrays "
-                    f"must have equal lengths; got {lengths}."
-                )
+            cell_types, cell_indices, centroids = self._validate_cell_data_lengths(
+                dataset_key, entry["cell_data"]
+            )
 
             tissue_attr = ""
             try:
@@ -404,6 +400,23 @@ class FullImageDataset(Dataset):
                         centroid=tuple(centroid),
                     )
                 )
+
+    @staticmethod
+    def _validate_cell_data_lengths(dataset_key, cell_data):
+        """Reject a ``cell_data`` triple whose arrays disagree in length.
+
+        ``cell_data`` is ``(cell_types, cell_indices, centroids)``; a mismatch
+        would silently misalign labels with cells, so fail loudly instead.
+        Returns the (validated) triple for convenient unpacking.
+        """
+        cell_types, cell_indices, centroids = cell_data
+        lengths = (len(cell_types), len(cell_indices), len(centroids))
+        if len(set(lengths)) != 1:
+            raise ValueError(
+                f"{dataset_key}: cell_type, cell_index, and centroid arrays "
+                f"must have equal lengths; got {lengths}."
+            )
+        return cell_types, cell_indices, centroids
 
     @staticmethod
     def _load_cell_data_cache(cache_path, expected_keys, fingerprint):

--- a/deepcell_types/training/dataset.py
+++ b/deepcell_types/training/dataset.py
@@ -344,6 +344,12 @@ class FullImageDataset(Dataset):
                 domain = modality_attr
 
             cell_types, cell_indices, centroids = entry["cell_data"]
+            lengths = (len(cell_types), len(cell_indices), len(centroids))
+            if len(set(lengths)) != 1:
+                raise ValueError(
+                    f"{dataset_key}: cell_type, cell_index, and centroid arrays "
+                    f"must have equal lengths; got {lengths}."
+                )
 
             tissue_attr = ""
             try:

--- a/deepcell_types/training/samplers.py
+++ b/deepcell_types/training/samplers.py
@@ -210,7 +210,7 @@ class FOVGroupedSampler(Sampler):
         self.replacement = replacement
         self._base_seed = int(seed)
         self._epoch = 0
-        # Map sampler position i -> ds_idx of the i-th train sample (Fix 1).
+        # Map sampler position i to the dataset index of the i-th train sample.
         # drawn[i] is a position in [0, len(train_indices)), so _ds_idx_map[drawn[i]]
         # gives the correct ds_idx for FOV grouping.
         self._ds_idx_map = torch.tensor(

--- a/deepcell_types/utils/__init__.py
+++ b/deepcell_types/utils/__init__.py
@@ -167,8 +167,8 @@ def download_baseline_checkpoint(name):
         raise ValueError(
             "The Nimbus baseline is inference-only and its pretrained weights "
             "are distributed upstream, not re-hosted by this project. Install "
-            "the official library (`pip install -e '.[baseline-nimbus]'`), which "
-            "downloads the weights automatically; see "
+            "the official library (`pip install nimbus-inference==0.0.5` on "
+            "Python 3.11), which downloads the weights automatically; see "
             f"{_NIMBUS_UPSTREAM_URL}."
         )
     if name not in _baseline_registry:

--- a/deepcell_types/utils/_auth.py
+++ b/deepcell_types/utils/_auth.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from hashlib import md5, sha256
 from tqdm import tqdm
 import logging
+import tempfile
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,13 @@ _asset_location = Path.home() / ".deepcell"
 # working while new assets can pin the stronger sha256. SHA-256 is preferred for
 # new entries (md5 is collision-weak).
 _HASH_BY_HEXLEN = {32: ("md5", md5), 64: ("sha256", sha256)}
+
+# Deliberately generous limits accommodate the public multi-terabyte corpus
+# while still bounding hostile or accidentally unbounded responses/archives.
+MAX_DOWNLOAD_BYTES = 10 * 2**40
+MAX_ARCHIVE_MEMBERS = 100_000
+MAX_ARCHIVE_MEMBER_BYTES = 2 * 2**40
+MAX_ARCHIVE_TOTAL_BYTES = 10 * 2**40
 
 
 def _hash_file(fpath, file_hash):
@@ -41,7 +49,13 @@ def _hash_file(fpath, file_hash):
     return algo_name, hasher.hexdigest()
 
 
-def fetch_data(asset_key: str, cache_subdir=None, file_hash=None):
+def fetch_data(
+    asset_key: str,
+    cache_subdir=None,
+    file_hash=None,
+    *,
+    max_download_bytes=MAX_DOWNLOAD_BYTES,
+):
     """Fetch assets through users.deepcell.org authentication system.
 
     Download assets from the deepcell suite of datasets and models which
@@ -68,6 +82,8 @@ def fetch_data(asset_key: str, cache_subdir=None, file_hash=None):
         the length. The checksum is used to perform data caching. If no checksum
         is provided or the checksum differs from that found in the data cache,
         the data will be (re)-downloaded.
+
+        :param max_download_bytes: Maximum number of response bytes accepted.
     """
     download_location = _asset_location
     if cache_subdir is not None:
@@ -171,43 +187,78 @@ def fetch_data(asset_key: str, cache_subdir=None, file_hash=None):
     )
     data_req.raise_for_status()
 
+    content_length = data_req.headers.get("Content-Length")
+    if content_length is not None:
+        try:
+            declared_bytes = int(content_length)
+        except ValueError as exc:
+            raise ValueError(
+                f"Download for {asset_key} returned an invalid Content-Length: "
+                f"{content_length!r}."
+            ) from exc
+        if declared_bytes > max_download_bytes:
+            raise ValueError(
+                f"Download for {asset_key} declares {declared_bytes} bytes, "
+                f"exceeding the {max_download_bytes}-byte safety limit."
+            )
+
     chunk_size = 4096
+    tmp_path = None
     try:
-        with tqdm.wrapattr(
-            open(fpath, "wb"), "write", miniters=1, total=file_size_numerical
-        ) as fh:
-            for chunk in data_req.iter_content(chunk_size=chunk_size):
-                fh.write(chunk)
+        with tempfile.NamedTemporaryFile(
+            mode="wb", dir=download_location, prefix=f".{fname}.", delete=False
+        ) as raw_fh:
+            tmp_path = Path(raw_fh.name)
+            with tqdm.wrapattr(
+                raw_fh, "write", miniters=1, total=file_size_numerical
+            ) as fh:
+                downloaded = 0
+                for chunk in data_req.iter_content(chunk_size=chunk_size):
+                    if not chunk:
+                        continue
+                    downloaded += len(chunk)
+                    if downloaded > max_download_bytes:
+                        raise ValueError(
+                            f"Download for {asset_key} exceeded the "
+                            f"{max_download_bytes}-byte safety limit."
+                        )
+                    fh.write(chunk)
+                fh.flush()
+                os.fsync(fh.fileno())
+
+        if file_hash is not None:
+            algo_name, actual = _hash_file(tmp_path, file_hash)
+            if actual != file_hash:
+                raise ValueError(
+                    f"Integrity check failed for {fname}: "
+                    f"expected {algo_name}={file_hash}, got {algo_name}={actual}. "
+                    "The downloaded file has been removed; please retry."
+                )
+        os.replace(tmp_path, fpath)
+        tmp_path = None
     except BaseException:
-        # Don't leave a half-written file on disk: subsequent runs (especially
-        # for callers that don't pass file_hash) would silently return the
-        # corrupt path. Drop and re-raise.
-        if fpath.exists():
+        # Preserve an existing cache entry; only the unique temporary download
+        # is removed when transfer or validation fails.
+        if tmp_path is not None:
             try:
-                fpath.unlink()
+                tmp_path.unlink(missing_ok=True)
             except OSError:
                 pass
         raise
-
-    # Verify the downloaded file against the expected hash, if one was given.
-    # This catches truncated downloads that completed without raising and
-    # protects against tampered intermediaries.
-    if file_hash is not None:
-        algo_name, actual = _hash_file(fpath, file_hash)
-        if actual != file_hash:
-            fpath.unlink(missing_ok=True)
-            raise ValueError(
-                f"Integrity check failed for {fname}: "
-                f"expected {algo_name}={file_hash}, got {algo_name}={actual}. "
-                "The downloaded file has been removed; please retry."
-            )
 
     logger.info(f"Successfully downloaded {fname} to {fpath}")
 
     return fpath
 
 
-def extract_archive(archive_path, dest=None):
+def extract_archive(
+    archive_path,
+    dest=None,
+    *,
+    max_members=MAX_ARCHIVE_MEMBERS,
+    max_member_bytes=MAX_ARCHIVE_MEMBER_BYTES,
+    max_total_bytes=MAX_ARCHIVE_TOTAL_BYTES,
+):
     """Safely extract a ``.zip`` or ``.tar[.gz]`` archive.
 
     Rejects members whose resolved path would escape ``dest`` (zip-slip /
@@ -240,18 +291,59 @@ def extract_archive(archive_path, dest=None):
 
     if zipfile.is_zipfile(archive_path):
         with zipfile.ZipFile(archive_path) as zf:
-            for member in zf.namelist():
-                if not _within(member):
+            infos = zf.infolist()
+            if len(infos) > max_members:
+                raise ValueError(
+                    f"Refusing to extract archive with {len(infos)} members; "
+                    f"limit is {max_members}."
+                )
+            total = 0
+            for member in infos:
+                is_symlink = (member.external_attr >> 16) & 0o170000 == 0o120000
+                if not _within(member.filename):
                     raise ValueError(
-                        f"Refusing to extract {member!r}: path escapes {dest}."
+                        f"Refusing to extract {member.filename!r}: path escapes {dest}."
+                    )
+                if is_symlink:
+                    raise ValueError(
+                        f"Refusing to extract unsafe zip member {member.filename!r}."
+                    )
+                if member.file_size > max_member_bytes:
+                    raise ValueError(
+                        f"Refusing to extract {member.filename!r}: declared size "
+                        f"exceeds {max_member_bytes} bytes."
+                    )
+                total += member.file_size
+                if total > max_total_bytes:
+                    raise ValueError(
+                        f"Refusing to extract archive larger than "
+                        f"{max_total_bytes} bytes."
                     )
             zf.extractall(dest)
     elif tarfile.is_tarfile(archive_path):
         with tarfile.open(archive_path) as tf:
-            for member in tf.getmembers():
-                if member.islnk() or member.issym() or not _within(member.name):
+            members = tf.getmembers()
+            if len(members) > max_members:
+                raise ValueError(
+                    f"Refusing to extract archive with {len(members)} members; "
+                    f"limit is {max_members}."
+                )
+            total = 0
+            for member in members:
+                if not (member.isfile() or member.isdir()) or not _within(member.name):
                     raise ValueError(
                         f"Refusing to extract unsafe tar member {member.name!r}."
+                    )
+                if member.size > max_member_bytes:
+                    raise ValueError(
+                        f"Refusing to extract {member.name!r}: declared size "
+                        f"exceeds {max_member_bytes} bytes."
+                    )
+                total += member.size
+                if total > max_total_bytes:
+                    raise ValueError(
+                        f"Refusing to extract archive larger than "
+                        f"{max_total_bytes} bytes."
                     )
             tf.extractall(dest, filter="data")
     else:

--- a/deepcell_types/utils/_auth.py
+++ b/deepcell_types/utils/_auth.py
@@ -108,6 +108,17 @@ def fetch_data(
             )
         except FileNotFoundError:
             pass
+    elif fpath.exists():
+        # No integrity hash is available for this asset (e.g. the large public
+        # training corpus, for which no authoritative digest is published).
+        # Reuse an existing local copy rather than re-downloading it — but its
+        # contents are not verified, so say so loudly.
+        logger.warning(
+            f"Reusing cached {fname} at {fpath} WITHOUT an integrity check "
+            "(no file_hash is available for this asset). Delete the file to "
+            "force a fresh download."
+        )
+        return fpath
 
     # Check for access token
     access_token = os.environ.get("DEEPCELL_ACCESS_TOKEN")
@@ -178,6 +189,11 @@ def fetch_data(
     except (ValueError, KeyError, AttributeError):
         file_size_numerical = None
 
+    if file_hash is None:
+        logger.warning(
+            f"Downloading {asset_key} WITHOUT an integrity check "
+            "(no file_hash is available for this asset)."
+        )
     logger.info(f"Downloading {asset_key} with size {file_size} to {download_location}")
     data_req = requests.get(
         download_url,

--- a/docs/index.md
+++ b/docs/index.md
@@ -165,9 +165,9 @@ checkpoints. Training-only code lives under `deepcell_types.training` and is
 gated behind the `[train]` install extra so plain inference users don't pull
 in `zarr`, `pandas`, `scikit-learn`, etc.
 
-```bash
-pip install "deepcell-types[train] @ git+https://github.com/vanvalenlab/deepcell-types@master"
-```
+These commands are source-checkout workflows and are not installed by the
+wheel. Clone the repository and run `uv sync --extra train` from its root before
+using `scripts/...`; see the README's Training section for complete commands.
 
 The end-to-end training and evaluation scripts live under `scripts/`:
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,8 @@ pandas
 napari
 pyqt6
 s3fs
-git+https://github.com/vanvalenlab/cellSAM
+# Immutable revision reviewed with this documentation environment.
+git+https://github.com/vanvalenlab/cellSAM@362a8e521bcd7313d5cb280bcd4cfc12977c1e9f
 # For (local) interactive tutorial
 jupyter
 jupyterlab-myst

--- a/docs/site/API-key.md
+++ b/docs/site/API-key.md
@@ -52,9 +52,9 @@ download_baseline_checkpoint("maps")
 ```
 
 The Nimbus baseline is not served here: its pretrained weights are
-distributed upstream, so install it with `pip install -e ".[baseline-nimbus]"`
-(which fetches the weights automatically) rather than
-`download_baseline_checkpoint`.
+distributed upstream, so install it with
+`pip install nimbus-inference==0.0.5` on Python 3.11 (which fetches the weights
+automatically) rather than `download_baseline_checkpoint`.
 
 Training Data
 -------------

--- a/docs/site/tutorial.md
+++ b/docs/site/tutorial.md
@@ -247,26 +247,8 @@ mask_lyr = nim.add_labels(mask, name="CellSAM segmentation")
 mask_lyr.contour = 3  # Relatively thick borders for static viz
 ```
 
-```{code-cell} ipython3
-:tags: [hide-cell]
-
-# For static rendering - can safely be ignored if running notebook interactively
-from pathlib import Path
-
-screenshot_path = Path("../_static/_generated")
-screenshot_path.mkdir(parents=True, exist_ok=True)
-nim.screenshot(
-    path=screenshot_path / "napari_img_and_segmentation.png",
-    canvas_only=False,
-);
-```
-
-<center>
-  <img src="../_static/_generated/napari_img_and_segmentation.png"
-       alt="Napari window of multiplexed image and computed segmentation mask"
-       width=100%
-  />
-</center>
+The image and segmentation layers appear directly in the interactive Napari
+viewer. Static documentation builds do not execute or embed GUI screenshots.
 
 
 ### Cell-type inference with `deepcell-types`
@@ -341,8 +323,8 @@ mapping explicit:
 cell. To enable it, pass a float `k`: `predict` then flags cells whose
 top-class probability falls below an IQR fence on the field-of-view's
 confidence distribution and rewrites their label to the sentinel `"Unknown"`.
-The paper's headline numbers are full-coverage (no abstention); `k=0.2` is a
-historical opt-in ablation, shown here only to illustrate how to enable it:
+Reported results use full coverage (no abstention). The following example shows
+how to opt into an IQR-fence threshold with `k=0.2`:
 
     cell_types = deepcell_types.predict(
         img, mask, chnames, mpp,
@@ -419,26 +401,9 @@ for k, l in labels_by_celltype.items():
     )
 ```
 
-```{code-cell} ipython3
-:tags: [hide-cell]
-
-# For static rendering - can safely be ignored if running notebook interactively
-from pathlib import Path
-
-screenshot_path = Path("../_static/_generated")
-screenshot_path.mkdir(parents=True, exist_ok=True)
-nim.screenshot(
-    path=screenshot_path / "napari_celltype_layers.png",
-    canvas_only=False,
-);
-```
-
-<center>
-  <img src="../_static/_generated/napari_celltype_layers.png"
-       alt="Napari window of multiplexed image with celltype predictions"
-       width=100%
-  />
-</center>
+When running interactively, the new label layers appear directly in the Napari
+viewer and can be toggled independently. Static documentation builds do not
+execute or embed GUI screenshots.
 
 [hubmap-data-portal]: https://portal.hubmapconsortium.org/search/datasets
 [zarr]: https://zarr.readthedocs.io/en/stable/

--- a/scripts/check_release_archive.sh
+++ b/scripts/check_release_archive.sh
@@ -5,36 +5,36 @@
 #
 # `all_standardized_channels` IS the released model's marker->index map
 # (config.DCTConfig builds marker2idx = enumerate(all_standardized_channels)),
-# and the released checkpoint + embeddings/svd_512.npz are built for that exact
+# and the released checkpoint is built for that exact
 # order. Reordering or resizing it silently misaligns the checkpoint's
 # per-marker weights, or fails the n_markers guard in predict._build_model so
 # the checkpoint won't load. This wrapper runs the archive-contract validator
 # with the released marker order as the reference and exits non-zero on any
 # drift, so it can be dropped into a release pipeline or run by hand.
 #
-# (GitHub CI cannot run this — the multi-TB archive and the released svd are not
+# (GitHub CI cannot run this — the multi-TB archive and released marker map are not
 # present there; the validator's own unit tests do run in CI. Run this wherever
-# the real archive + released embeddings live, as a pre-publish step.)
+# the real archive + released marker map live, as a pre-publish step.)
 #
 # Usage:
-#   scripts/check_release_archive.sh <archive.zarr> <svd_512.npz>
+#   scripts/check_release_archive.sh <archive.zarr> <marker_order.json>
 # or via environment variables:
 #   DEEPCELL_TYPES_ZARR_PATH=/path/to/archive.zarr \
-#   DCT_RELEASE_SVD=/path/to/embeddings/svd_512.npz \
+#   DCT_RELEASE_MARKER_ORDER=/path/to/marker_order.json \
 #   scripts/check_release_archive.sh
 #
 set -euo pipefail
 
 ARCHIVE="${1:-${DEEPCELL_TYPES_ZARR_PATH:-}}"
-SVD="${2:-${DCT_RELEASE_SVD:-}}"
+MARKER_ORDER="${2:-${DCT_RELEASE_MARKER_ORDER:-}}"
 
-if [[ -z "${ARCHIVE}" || -z "${SVD}" ]]; then
-    echo "usage: $0 <archive.zarr> <svd_512.npz>" >&2
-    echo "   or: set DEEPCELL_TYPES_ZARR_PATH and DCT_RELEASE_SVD" >&2
+if [[ -z "${ARCHIVE}" || -z "${MARKER_ORDER}" ]]; then
+    echo "usage: $0 <archive.zarr> <marker_order.json>" >&2
+    echo "   or: set DEEPCELL_TYPES_ZARR_PATH and DCT_RELEASE_MARKER_ORDER" >&2
     exit 2
 fi
 
 here="$(cd "$(dirname "$0")" && pwd)"
 exec python "${here}/validate_archive_contract.py" \
     --zarr "${ARCHIVE}" \
-    --marker-order-from "${SVD}"
+    --marker-order-from "${MARKER_ORDER}"

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -24,6 +24,7 @@ from deepcell_types.training.dataset import create_dataloader
 from deepcell_types.model import create_model
 from deepcell_types.predict import (
     validate_checkpoint_vocabulary,
+    validate_checkpoint_architecture_config,
     _infer_ct_head_params,
 )
 from deepcell_types.training.losses import FocalLoss
@@ -254,6 +255,7 @@ def main(
     # of the right size would load cleanly and silently mislabel every cell in
     # the eval CSV. Same check the Python API runs.
     validate_checkpoint_vocabulary(checkpoint, dct_config.ct2idx, dct_config.marker2idx)
+    n_heads, compat_marker0_zero = validate_checkpoint_architecture_config(checkpoint)
 
     # Build model
     model = create_model(
@@ -262,9 +264,9 @@ def main(
         d_model=d_model,
         resnet_base_channels=ckpt_config.get("resnet_channels", resnet_channels),
         spatial_pool_size=ckpt_config.get("spatial_pool_size", spatial_pool_size),
-        n_heads=ckpt_config.get("n_heads", 8),
+        n_heads=n_heads,
         use_conditioned_mp_head=ckpt_config.get("use_conditioned_mp_head", True),
-        compat_marker0_zero=ckpt_config.get("compat_marker0_zero", True),
+        compat_marker0_zero=compat_marker0_zero,
         ct_head_width=ct_head_params["ct_head_width"],
         ct_head_depth=ct_head_params["ct_head_depth"],
     )

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -78,7 +78,12 @@ def _resolve_marker_embeddings(dct_config, state_dict, svd_path):
 
 @click.command()
 @click.option("--model_name", type=str, default="deepcell-types")
-@click.option("--device_num", type=str, default="cuda:0")
+@click.option(
+    "--device_num",
+    type=str,
+    default="auto",
+    help="Torch device. 'auto' selects cuda:0 when available, otherwise cpu.",
+)
 @click.option("--zarr_dir", type=str, default=str(DATA_DIR))
 @click.option("--skip_datasets", type=str, multiple=True, default=[])
 @click.option("--keep_datasets", type=str, multiple=True, default=[])
@@ -139,11 +144,8 @@ def _resolve_marker_embeddings(dct_config, state_dict, svd_path):
     default=0.0,
     help=(
         "Per-FOV IQR-fence abstention on max-softmax confidence. "
-        "Default is 0 (disabled) — the current paper headline (Fig 3c) uses no "
-        "abstention, full coverage. k=0.2 was an earlier paper draft's "
-        "operating point; IQR-fence abstention was removed from the paper "
-        "(see analysis/_score_csv.py in the research workspace) and remains "
-        "available here only as a historical ablation, opt-in via this flag. "
+        "Default is 0 (disabled), which returns a prediction for every cell. "
+        "Positive values opt into IQR-fence abstention. "
         "Cells whose max-softmax falls below Q1 - k*IQR within their "
         "(dataset_name, fov_name) group are flagged as abstained "
         "(predicted_ct = 'Unknown', original kept in predicted_ct_raw). "
@@ -170,6 +172,9 @@ def main(
     ct_abstention_k,
 ):
     seed_everything(seed)
+
+    if device_num == "auto":
+        device_num = "cuda:0" if torch.cuda.is_available() else "cpu"
 
     device = torch.device(device_num)
     dct_config = TissueNetConfig(zarr_dir)
@@ -396,7 +401,7 @@ def main(
             # Forward — only request attention weights when --save_attention
             # is set. Asking for them unconditionally disables PyTorch's fast
             # SDPA kernel and forces a slower per-head materialised attention
-            # path. Per the deep-review (perf): gating saves ~15% wall-clock
+            # path. Gating avoids the cost of collecting attention weights
             # on a typical predict run because that kernel is the bottleneck.
             outputs = model(
                 batch_data.sample,

--- a/scripts/pretrain.py
+++ b/scripts/pretrain.py
@@ -46,7 +46,12 @@ DATA_DIR = Path(
 
 @click.command()
 @click.option("--model_name", type=str, default="pretrain")
-@click.option("--device_num", type=str, default="cuda:0")
+@click.option(
+    "--device_num",
+    type=str,
+    default="auto",
+    help="Torch device. 'auto' selects cuda:0 when available, otherwise cpu.",
+)
 @click.option("--zarr_dir", type=str, default=str(DATA_DIR))
 @click.option("--skip_datasets", type=str, multiple=True, default=[])
 @click.option("--keep_datasets", type=str, multiple=True, default=[])
@@ -123,6 +128,9 @@ def main(
 ):
     seed_everything(seed)
 
+    if device_num == "auto":
+        device_num = "cuda:0" if torch.cuda.is_available() else "cpu"
+
     device = torch.device(device_num)
     # AMP is only supported on CUDA; disable automatically on CPU
     enable_amp = enable_amp and device.type == "cuda"
@@ -188,7 +196,7 @@ def main(
     # GradScaler for AMP (no-op when enable_amp=False)
     scaler = torch.amp.GradScaler("cuda", enabled=enable_amp)
 
-    # ---------- Checkpoint helpers (R4 H1: full training-state checkpoints) ----------
+    # Full training-state checkpoint helpers.
     CKPT_CONFIG = {
         "d_model": d_model,
         "resnet_channels": 48,  # matches create_model(resnet_base_channels=48) default
@@ -217,13 +225,15 @@ def main(
     best_model_path = Path(f"models/model_{model_name}_best.pt")
     best_model_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # ---------- R4 H1: full training-state resume ----------
+    # Resume the full training state when available.
     start_epoch = 0
     if resume_path is not None:
         if not Path(resume_path).exists():
             raise FileNotFoundError(f"--resume_path {resume_path} does not exist")
         logger.info("Resuming from %s", resume_path)
-        resume_ckpt = torch.load(resume_path, map_location=device, weights_only=False)  # trusted local ckpt (pretrain.py writes numpy scalars)
+        resume_ckpt = torch.load(
+            resume_path, map_location=device, weights_only=False
+        )  # trusted local ckpt (pretrain.py writes numpy scalars)
 
         if not isinstance(resume_ckpt, dict) or "optimizer" not in resume_ckpt:
             # Legacy pretrain checkpoint is a plain state_dict (model backbone only).
@@ -266,9 +276,7 @@ def main(
             # scheduler.load_state_dict() here would silently overwrite
             # total_steps with the checkpointed run's value, discarding an
             # increased --epochs.
-            resume_onecycle_schedule(
-                scheduler, resume_ckpt["scheduler"], logger=logger
-            )
+            resume_onecycle_schedule(scheduler, resume_ckpt["scheduler"], logger=logger)
             scaler.load_state_dict(resume_ckpt["scaler"])
             start_epoch = int(resume_ckpt["epoch"]) + 1
             best_val_loss = float(resume_ckpt.get("best_val_loss", float("inf")))
@@ -292,7 +300,7 @@ def main(
         model.train()
         recon_head.train()
         train_losses = defaultdict(list)
-        train_valid_mp_batches = 0  # R5 L1: track batches where MP loss was non-trivial
+        train_valid_mp_batches = 0  # Batches with non-trivial marker-positivity loss.
         val_valid_mp_batches = 0
 
         for batch in tqdm(train_loader, desc=f"Epoch {epoch} (pretrain)", leave=False):
@@ -426,7 +434,7 @@ def main(
         val_summary = {k: np.mean(v) for k, v in val_losses.items()}
         print(f"Epoch {epoch} val: {val_summary}")
 
-        # R5 L1: warn if MP-loss mask was empty for the entire epoch (train or val);
+        # Warn if the marker-positivity mask was empty for the entire epoch;
         # otherwise the reported mp_loss average is effectively zero with no signal.
         if marker_pos_weight > 0:
             if train_valid_mp_batches == 0:

--- a/scripts/repackage_release_checkpoint.py
+++ b/scripts/repackage_release_checkpoint.py
@@ -87,7 +87,14 @@ def main():
     )
     args = parser.parse_args()
 
-    ckpt = torch.load(args.checkpoint, map_location="cpu", weights_only=False)
+    try:
+        ckpt = torch.load(args.checkpoint, map_location="cpu", weights_only=True)
+    except Exception as exc:
+        raise SystemExit(
+            "Checkpoint could not be loaded in restricted weights-only mode. "
+            "Do not repackage an untrusted legacy pickle checkpoint; convert it "
+            "in an isolated environment first."
+        ) from exc
     cfg = DCTConfig(zarr_path=args.zarr_path)
     try:
         bundle_vocabulary(ckpt, cfg)

--- a/scripts/retrain_head.py
+++ b/scripts/retrain_head.py
@@ -66,7 +66,11 @@ def _extract_cls(model, loader, device, desc):
 @click.option(
     "--output", required=True, help="Path for the deployable resMLP checkpoint"
 )
-@click.option("--device_num", default="cuda:0")
+@click.option(
+    "--device_num",
+    default="auto",
+    help="Torch device. 'auto' selects cuda:0 when available, otherwise cpu.",
+)
 @click.option("--batch_size", type=int, default=512)
 @click.option("--num_workers", type=int, default=12)
 @click.option("--epochs", type=int, default=50)
@@ -90,6 +94,8 @@ def main(
     seed,
 ):
     seed_everything(seed)
+    if device_num == "auto":
+        device_num = "cuda:0" if torch.cuda.is_available() else "cpu"
     device = torch.device(device_num)
     cfg = TissueNetConfig(zarr_dir)
     marker_emb = cfg.load_marker_embeddings_array(svd_path=svd_embeddings_path)
@@ -110,7 +116,9 @@ def main(
         pin_memory=True,
     )
 
-    ck = torch.load(pretrained_path, map_location=device, weights_only=False)  # trusted local ckpt (pretrain.py writes numpy scalars)
+    ck = torch.load(
+        pretrained_path, map_location=device, weights_only=False
+    )  # trusted local ckpt (pretrain.py writes numpy scalars)
     cc = ck.get("config", {}) if isinstance(ck, dict) else {}
     model = create_model(
         cfg,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -196,7 +196,12 @@ def forward_one_batch(
 
 @click.command()
 @click.option("--model_name", type=str, default="deepcell-types")
-@click.option("--device_num", type=str, default="cuda:0")
+@click.option(
+    "--device_num",
+    type=str,
+    default="auto",
+    help="Torch device. 'auto' selects cuda:0 when available, otherwise cpu.",
+)
 @click.option("--zarr_dir", type=str, default=str(DATA_DIR))
 @click.option("--skip_datasets", type=str, multiple=True, default=[])
 @click.option("--keep_datasets", type=str, multiple=True, default=[])
@@ -367,6 +372,9 @@ def main(
     # Seed everything
     seed_everything(seed)
 
+    if device_num == "auto":
+        device_num = "cuda:0" if torch.cuda.is_available() else "cpu"
+
     if debug:
         torch.autograd.set_detect_anomaly(True)
 
@@ -431,7 +439,9 @@ def main(
     if pretrained_path and Path(pretrained_path).exists():
         print(f"Loading pre-trained weights from {pretrained_path}")
         pretrained_state = torch.load(
-            pretrained_path, map_location=device, weights_only=False  # trusted local ckpt; pretrain.py saves numpy scalars
+            pretrained_path,
+            map_location=device,
+            weights_only=False,  # trusted local ckpt; pretrain.py saves numpy scalars
         )
         # Accept both the legacy plain-state_dict and the new bundled checkpoint
         # (which stores the backbone under the "model" key).
@@ -500,7 +510,7 @@ def main(
     # GradScaler for AMP (no-op when enable_amp=False)
     scaler = torch.amp.GradScaler("cuda", enabled=enable_amp)
 
-    # ---------- Checkpoint helpers (R4 H1: full training-state checkpoints) ----------
+    # Full training-state checkpoint helpers.
     # Snapshot of training-time config that must match on resume. If these differ we
     # can't restore optimizer/scheduler state sanely, so we raise.
     # CKPT_CONFIG is bundled into every saved checkpoint AND written to a
@@ -631,13 +641,15 @@ def main(
     best_model_path = Path(f"models/model_{model_name}_best.pt")
     best_model_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # ---------- R4 H1: full training-state resume ----------
+    # Resume the full training state when available.
     start_epoch = 0
     if resume_path is not None:
         if not Path(resume_path).exists():
             raise FileNotFoundError(f"--resume_path {resume_path} does not exist")
         logger.info("Resuming from %s", resume_path)
-        resume_ckpt = torch.load(resume_path, map_location=device, weights_only=False)  # trusted local ckpt
+        resume_ckpt = torch.load(
+            resume_path, map_location=device, weights_only=False
+        )  # trusted local ckpt
 
         if not isinstance(resume_ckpt, dict) or "optimizer" not in resume_ckpt:
             # Legacy checkpoint (only `model` key, or plain state_dict): fall back to
@@ -694,9 +706,7 @@ def main(
             # scheduler.load_state_dict() here would silently overwrite
             # total_steps with the checkpointed run's value, discarding an
             # increased --epochs.
-            resume_onecycle_schedule(
-                scheduler, resume_ckpt["scheduler"], logger=logger
-            )
+            resume_onecycle_schedule(scheduler, resume_ckpt["scheduler"], logger=logger)
             scaler.load_state_dict(resume_ckpt["scaler"])
             start_epoch = int(resume_ckpt["epoch"]) + 1
             # New key "best_val_macro_f1"; fall back to the legacy
@@ -862,7 +872,9 @@ def main(
     # test number. It is labeled "val_final" accordingly. The held-out test metric
     # for the paper is produced by `scripts/predict.py` on the split file's
     # `heldout` FOVs (which load_fov_splits excludes from both train and val).
-    checkpoint = torch.load(best_model_path, map_location=device, weights_only=False)  # trusted local ckpt
+    checkpoint = torch.load(
+        best_model_path, map_location=device, weights_only=False
+    )  # trusted local ckpt
     model.load_state_dict(checkpoint["model"])
     model.eval()
 

--- a/scripts/validate_archive_contract.py
+++ b/scripts/validate_archive_contract.py
@@ -244,17 +244,18 @@ def check_marker_index_order(
 def _load_expected_marker_order(path: Path) -> list[str]:
     """Load the released model's frozen marker order (source of truth).
 
-    Accepts the released embeddings ``.npz`` (whose ``marker2idx`` object holds
-    the ``{marker: index}`` map) or a JSON file containing either a
-    ``{marker: index}`` dict or an ordered list of marker names.
+    Accepts a JSON file containing either a ``{marker: index}`` dict or an
+    ordered list of marker names. JSON is required because NumPy object arrays
+    rely on pickle deserialization and are not safe release-contract inputs.
     """
     path = Path(path)
-    if path.suffix == ".npz":
-        import numpy as np
-
-        data = np.load(path, allow_pickle=True)
-        marker2idx = data["marker2idx"].item()
-        return [m for m, _ in sorted(marker2idx.items(), key=lambda kv: kv[1])]
+    if path.suffix != ".json":
+        suffix = path.suffix or "a file without an extension"
+        raise ValueError(
+            f"Marker order must be supplied as JSON, not {suffix}; "
+            "NumPy object archives require unsafe "
+            "pickle deserialization."
+        )
     obj = _read_json(path)
     if isinstance(obj, dict):
         return [m for m, _ in sorted(obj.items(), key=lambda kv: kv[1])]
@@ -484,8 +485,8 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         default=None,
         help=(
-            "Path to the released model's embeddings .npz (with a marker2idx "
-            "object) or a JSON marker2idx/ordered-list. When set, assert that the "
+            "Path to a JSON marker2idx mapping or ordered marker list. When set, "
+            "assert that the "
             "archive's all_standardized_channels matches that frozen marker→index "
             "order exactly. Guards against the checkpoint-breaking reorder/resize."
         ),

--- a/scripts/validate_archive_contract.py
+++ b/scripts/validate_archive_contract.py
@@ -196,8 +196,8 @@ def check_marker_index_order(
     ``svd_512.npz`` marker embeddings are built for that exact order. Reordering
     or resizing it silently misaligns the checkpoint's per-marker weights, or
     trips the ``n_markers`` guard in ``predict._build_model`` so the released
-    checkpoint fails to load. This caught a real incident (2026-06-01) where the
-    registry was re-accumulated to a 327-channel union and re-sorted.
+    checkpoint fails to load. Ordered comparison is required because equal
+    marker names in a different order still misalign checkpoint weights.
 
     Returns a list of human-readable error strings (empty == contract holds).
     """

--- a/tests/baselines/conftest.py
+++ b/tests/baselines/conftest.py
@@ -24,7 +24,7 @@ if not (_have("xgboost") and _have("optuna")):
 if not _have("pandas"):
     collect_ignore.append("test_nimbus_metrics_characterization.py")
 if not _have("pandas"):
-    collect_ignore.append("test_runner_round2.py")
+    collect_ignore.append("test_maps_cellsighter_cli.py")
 # cellsighter.model imports torchvision AND (via deepcell_types.training.utils)
 # pandas, so both must be present or this test would error, not skip. torchvision
 # does not pull pandas, so guarding on torchvision alone is insufficient.

--- a/tests/baselines/test_maps_cellsighter_cli.py
+++ b/tests/baselines/test_maps_cellsighter_cli.py
@@ -1,8 +1,7 @@
-"""Registry + CLI option-snapshot tests for the round-2 baselines (maps, cellsighter).
+"""Registry and CLI option-snapshot tests for MAPS and CellSighter.
 
-Frozen option snapshots of the per-baseline click commands (re-frozen after the
-wandb logging option was removed across all baselines). cellsighter's command
-imports torchvision (via cellsighter.model), so its tests importorskip it.
+CellSighter's command imports torchvision through its model, so those tests
+skip when the optional dependency is unavailable.
 """
 
 import click

--- a/tests/baselines/test_nimbus_coverage_gate.py
+++ b/tests/baselines/test_nimbus_coverage_gate.py
@@ -11,12 +11,27 @@ a silent drop must never be invisible — hence the aggregate print happens
 unconditionally, even below threshold.
 """
 
+import click
+import pandas as pd
 import pytest
 
 from deepcell_types.baselines.nimbus.run import (
     NIMBUS_DATASET_FAILURE_RATE_THRESHOLD,
     check_dataset_coverage,
+    combine_predictions,
 )
+
+
+def test_combine_predictions_raises_on_empty():
+    # A run producing no predictions must fail loudly, not write an empty result.
+    with pytest.raises(click.ClickException, match="No predictions were generated"):
+        combine_predictions([])
+
+
+def test_combine_predictions_concatenates_frames():
+    frames = [pd.DataFrame({"cell": [1]}), pd.DataFrame({"cell": [2, 3]})]
+    out = combine_predictions(frames)
+    assert list(out["cell"]) == [1, 2, 3]
 
 
 def test_no_skips_reports_zero_and_does_not_raise(capsys):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,9 @@ install extra (``zarr``, ``pandas``, ``scikit-learn``, ``torchmetrics``, ...).
 On an inference-only checkout (``pip install -e .``) those packages are absent,
 and the affected tests must be *skipped*, not raise collection errors.
 
-Rather than hand-maintaining a list of which test file needs which extra (which
-can silently become stale whenever a new train-dependent test file is added
-when a missing entry turned the inference-only CI job red), we autodetect: for
+Rather than hand-maintaining a list of which test file needs which extra, which
+can silently become stale whenever a new train-dependent test file is added, we
+autodetect: for
 each ``test_*.py`` we parse its top-level imports and try to import them. If one
 fails because an *optional* (extra-only) package is missing -- directly or
 transitively, e.g. ``from deepcell_types.training.dataset import ...`` pulling

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ On an inference-only checkout (``pip install -e .``) those packages are absent,
 and the affected tests must be *skipped*, not raise collection errors.
 
 Rather than hand-maintaining a list of which test file needs which extra (which
-silently rots whenever a new train-dependent test file is added, and bit us
+can silently become stale whenever a new train-dependent test file is added
 when a missing entry turned the inference-only CI job red), we autodetect: for
 each ``test_*.py`` we parse its top-level imports and try to import them. If one
 fails because an *optional* (extra-only) package is missing -- directly or

--- a/tests/test_archive_contract_validator.py
+++ b/tests/test_archive_contract_validator.py
@@ -2,7 +2,10 @@
 
 import json
 
+import pytest
+
 from scripts.validate_archive_contract import (
+    _load_expected_marker_order,
     check_marker_index_order,
     validate_archive,
 )
@@ -11,6 +14,15 @@ from scripts.validate_archive_contract import (
 def _write_json(path, payload):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload))
+
+
+def test_marker_order_loader_accepts_json_and_rejects_numpy_pickle(tmp_path):
+    marker_order = tmp_path / "markers.json"
+    _write_json(marker_order, {"CD3": 1, "CD45": 0})
+    assert _load_expected_marker_order(marker_order) == ["CD45", "CD3"]
+
+    with pytest.raises(ValueError, match="must be supplied as JSON"):
+        _load_expected_marker_order(tmp_path / "embeddings.npz")
 
 
 def _write_fov(

--- a/tests/test_archive_contract_validator.py
+++ b/tests/test_archive_contract_validator.py
@@ -155,8 +155,7 @@ def test_validator_rejects_split_fov_absent_from_archive(tmp_path):
 # ---------------------------------------------------------------------------
 # Marker index-map guard: all_standardized_channels IS the released model's
 # frozen marker->index map. Reorder/resize silently breaks the checkpoint.
-# Regression guard for the 2026-06-01 incident (registry unioned to 327 +
-# re-sorted, which broke loading deepcell-types_2026-05-17.pt).
+# The validator must reject any reorder or resize before checkpoint loading.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -10,6 +10,7 @@ import hashlib
 import io
 import tarfile
 import zipfile
+import requests
 
 import pytest
 
@@ -111,6 +112,20 @@ def test_extract_archive_rejects_non_archive(tmp_path):
         extract_archive(plain, tmp_path / "out")
 
 
+def test_extract_archive_enforces_member_and_size_limits(tmp_path):
+    archive = tmp_path / "bounded.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("one", b"123")
+        zf.writestr("two", b"456")
+
+    with pytest.raises(ValueError, match="2 members"):
+        extract_archive(archive, tmp_path / "members", max_members=1)
+    with pytest.raises(ValueError, match="declared size"):
+        extract_archive(archive, tmp_path / "member-size", max_member_bytes=2)
+    with pytest.raises(ValueError, match="larger than"):
+        extract_archive(archive, tmp_path / "total-size", max_total_bytes=5)
+
+
 # --- fetch_data: cache-hit and missing-token branches (no network) ----------
 
 
@@ -135,6 +150,103 @@ def test_fetch_data_requires_token_on_cache_miss(tmp_path, monkeypatch):
     # (never hits the network in the test).
     with pytest.raises(ValueError, match="DEEPCELL_ACCESS_TOKEN"):
         fetch_data("models/missing.pt", cache_subdir="models", file_hash="0" * 32)
+
+
+class _Response:
+    def __init__(self, *, status=200, json_data=None, text="", chunks=(), headers=None):
+        self.status_code = status
+        self._json_data = json_data
+        self.text = text
+        self._chunks = chunks
+        self.headers = headers or {}
+
+    def json(self):
+        if isinstance(self._json_data, Exception):
+            raise self._json_data
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"HTTP {self.status_code}")
+
+    def iter_content(self, chunk_size):
+        del chunk_size
+        yield from self._chunks
+
+
+def _mock_download(monkeypatch, post_response, get_response):
+    monkeypatch.setenv("DEEPCELL_ACCESS_TOKEN", "test-token")
+    monkeypatch.setattr(_auth.requests, "post", lambda *args, **kwargs: post_response)
+    monkeypatch.setattr(_auth.requests, "get", lambda *args, **kwargs: get_response)
+
+
+def test_fetch_data_reports_non_json_http_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(_auth, "_asset_location", tmp_path)
+    _mock_download(
+        monkeypatch,
+        _Response(status=502, json_data=ValueError("not json"), text="gateway"),
+        _Response(),
+    )
+    with pytest.raises(requests.HTTPError, match="502"):
+        fetch_data("models/model.pt")
+
+
+def test_fetch_data_rejects_missing_download_url(tmp_path, monkeypatch):
+    monkeypatch.setattr(_auth, "_asset_location", tmp_path)
+    _mock_download(monkeypatch, _Response(json_data={}), _Response())
+    with pytest.raises(ValueError, match="missing download URL"):
+        fetch_data("models/model.pt")
+
+
+def test_fetch_data_preserves_cache_on_interrupted_refresh(tmp_path, monkeypatch):
+    monkeypatch.setattr(_auth, "_asset_location", tmp_path)
+    cached = tmp_path / "models" / "model.pt"
+    cached.parent.mkdir()
+    cached.write_bytes(b"previous")
+
+    def interrupted():
+        yield b"partial"
+        raise requests.ConnectionError("connection lost")
+
+    _mock_download(
+        monkeypatch,
+        _Response(json_data={"url": "https://example.invalid/model"}),
+        _Response(chunks=interrupted()),
+    )
+    with pytest.raises(requests.ConnectionError, match="connection lost"):
+        fetch_data("models/model.pt", cache_subdir="models", file_hash="0" * 32)
+    assert cached.read_bytes() == b"previous"
+    assert list(cached.parent.glob(".model.pt.*")) == []
+
+
+def test_fetch_data_rejects_oversized_stream_and_preserves_cache(tmp_path, monkeypatch):
+    monkeypatch.setattr(_auth, "_asset_location", tmp_path)
+    cached = tmp_path / "model.pt"
+    cached.write_bytes(b"previous")
+    _mock_download(
+        monkeypatch,
+        _Response(json_data={"url": "https://example.invalid/model"}),
+        _Response(chunks=[b"123", b"456"]),
+    )
+    with pytest.raises(ValueError, match="safety limit"):
+        fetch_data("model.pt", file_hash="0" * 32, max_download_bytes=5)
+    assert cached.read_bytes() == b"previous"
+
+
+def test_fetch_data_rejects_digest_mismatch_without_replacing_cache(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(_auth, "_asset_location", tmp_path)
+    cached = tmp_path / "model.pt"
+    cached.write_bytes(b"previous")
+    _mock_download(
+        monkeypatch,
+        _Response(json_data={"url": "https://example.invalid/model"}),
+        _Response(chunks=[b"wrong"]),
+    )
+    with pytest.raises(ValueError, match="Integrity check failed"):
+        fetch_data("model.pt", file_hash=hashlib.sha256(b"expected").hexdigest())
+    assert cached.read_bytes() == b"previous"
 
 
 # --- model registry shape ---------------------------------------------------

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -126,6 +126,24 @@ def test_extract_archive_enforces_member_and_size_limits(tmp_path):
         extract_archive(archive, tmp_path / "total-size", max_total_bytes=5)
 
 
+def test_extract_archive_enforces_member_and_size_limits_tar(tmp_path):
+    # The tar branch duplicates the zip branch's bound checks; exercise it
+    # directly so a tar-only regression can't slip through.
+    archive = tmp_path / "bounded.tar"
+    with tarfile.open(archive, "w") as tf:
+        for name, data in (("one", b"123"), ("two", b"456")):
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+
+    with pytest.raises(ValueError, match="2 members"):
+        extract_archive(archive, tmp_path / "members", max_members=1)
+    with pytest.raises(ValueError, match="declared size"):
+        extract_archive(archive, tmp_path / "member-size", max_member_bytes=2)
+    with pytest.raises(ValueError, match="larger than"):
+        extract_archive(archive, tmp_path / "total-size", max_total_bytes=5)
+
+
 # --- fetch_data: cache-hit and missing-token branches (no network) ----------
 
 
@@ -247,6 +265,61 @@ def test_fetch_data_rejects_digest_mismatch_without_replacing_cache(
     with pytest.raises(ValueError, match="Integrity check failed"):
         fetch_data("model.pt", file_hash=hashlib.sha256(b"expected").hexdigest())
     assert cached.read_bytes() == b"previous"
+
+
+def test_fetch_data_downloads_and_lands_atomically(tmp_path, monkeypatch):
+    # The happy path: a valid streamed download with a matching hash lands at
+    # download_location/fname with the exact bytes and leaves no temp file.
+    monkeypatch.setattr(_auth, "_asset_location", tmp_path)
+    payload = b"fresh model bytes"
+    digest = hashlib.md5(payload).hexdigest()
+    _mock_download(
+        monkeypatch,
+        _Response(json_data={"url": "https://example.invalid/model"}),
+        _Response(chunks=[payload[:5], payload[5:]]),
+    )
+    out = fetch_data("models/model.pt", cache_subdir="models", file_hash=digest)
+    assert out == tmp_path / "models" / "model.pt"
+    assert out.read_bytes() == payload
+    assert list(out.parent.glob(".model.pt.*")) == []
+
+
+def test_fetch_data_reuses_unhashed_cache_without_network(tmp_path, monkeypatch):
+    # With no file_hash and an existing cached file, fetch_data must return the
+    # cached path directly — never reaching the token check or the network.
+    monkeypatch.setattr(_auth, "_asset_location", tmp_path)
+    monkeypatch.delenv("DEEPCELL_ACCESS_TOKEN", raising=False)
+    cache_dir = tmp_path / "data"
+    cache_dir.mkdir()
+    (cache_dir / "corpus.zip").write_bytes(b"corpus")
+    out = fetch_data("data/corpus.zip", cache_subdir="data")
+    assert out == cache_dir / "corpus.zip"
+
+
+def test_fetch_data_rejects_oversized_content_length_before_writing(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(_auth, "_asset_location", tmp_path)
+    _mock_download(
+        monkeypatch,
+        _Response(json_data={"url": "https://example.invalid/model"}),
+        _Response(headers={"Content-Length": "999"}, chunks=[b"x"]),
+    )
+    with pytest.raises(ValueError, match="exceeding the"):
+        fetch_data("model.pt", max_download_bytes=5)
+    assert not (tmp_path / "model.pt").exists()
+
+
+def test_fetch_data_rejects_non_numeric_content_length(tmp_path, monkeypatch):
+    monkeypatch.setattr(_auth, "_asset_location", tmp_path)
+    _mock_download(
+        monkeypatch,
+        _Response(json_data={"url": "https://example.invalid/model"}),
+        _Response(headers={"Content-Length": "not-a-number"}, chunks=[b"x"]),
+    )
+    with pytest.raises(ValueError, match="invalid Content-Length"):
+        fetch_data("model.pt")
+    assert not (tmp_path / "model.pt").exists()
 
 
 # --- model registry shape ---------------------------------------------------

--- a/tests/test_canonical_inference.py
+++ b/tests/test_canonical_inference.py
@@ -512,6 +512,13 @@ def test_config_raises_when_explicit_archive_missing(tmp_path, monkeypatch):
         DCTConfig(zarr_path=tmp_path / "does-not-exist.zarr")
 
 
+def test_config_raises_when_environment_archive_missing(tmp_path, monkeypatch):
+    missing = tmp_path / "does-not-exist.zarr"
+    monkeypatch.setenv("DEEPCELL_TYPES_ZARR_PATH", str(missing))
+    with pytest.raises(FileNotFoundError, match="DEEPCELL_TYPES_ZARR_PATH"):
+        DCTConfig()
+
+
 def test_config_falls_back_to_packaged_vocab(monkeypatch):
     # No archive anywhere -> DCTConfig loads the packaged vocab.json snapshot,
     # so predict() works without the (large) TissueNet archive.
@@ -858,9 +865,7 @@ def test_predict_output_is_pinned_for_a_fixed_checkpoint(tmp_path):
     # just the discrete labels) catches numerics drift even when it does not
     # cross an argmax boundary. Regenerate deliberately if preprocessing or the
     # forward path changes on purpose.
-    np.testing.assert_allclose(
-        res.probabilities, _PINNED_PROBS_SEED0, atol=1e-4
-    )
+    np.testing.assert_allclose(res.probabilities, _PINNED_PROBS_SEED0, atol=1e-4)
 
 
 # Golden softmax matrix for test_predict_output_is_pinned_for_a_fixed_checkpoint

--- a/tests/test_canonical_inference.py
+++ b/tests/test_canonical_inference.py
@@ -129,8 +129,14 @@ def test_config_rejects_noncontiguous_cell_type_mapping(tmp_path):
 
 def test_config_mappings_are_read_only():
     config = DCTConfig()
+    # All exposed mappings must be immutable views, not the backing dicts.
+    for mapping in (config.ct2idx, config.marker2idx, config.domain2idx):
+        with pytest.raises(TypeError):
+            mapping["new"] = 0
+    # master_channels is exposed as an immutable tuple.
+    assert isinstance(config.master_channels, tuple)
     with pytest.raises(TypeError):
-        config.ct2idx["new"] = len(config.ct2idx)
+        config.master_channels[0] = "X"
 
 
 def test_invalid_archive_environment_variable_is_not_ignored(tmp_path, monkeypatch):

--- a/tests/test_canonical_inference.py
+++ b/tests/test_canonical_inference.py
@@ -116,6 +116,30 @@ def test_canonical_config_reads_contract_from_archive(tmp_path):
     }
 
 
+def test_config_rejects_noncontiguous_cell_type_mapping(tmp_path):
+    archive_path = _make_archive(tmp_path)
+    metadata_path = archive_path / "zarr.json"
+    metadata = json.loads(metadata_path.read_text())
+    metadata["attributes"]["cell_type_mapping"] = {"Bcell": 0, "Tumor": 2}
+    _write_json(metadata_path, metadata)
+
+    with pytest.raises(ValueError, match="unique and contiguous"):
+        DCTConfig(zarr_path=archive_path)
+
+
+def test_config_mappings_are_read_only():
+    config = DCTConfig()
+    with pytest.raises(TypeError):
+        config.ct2idx["new"] = len(config.ct2idx)
+
+
+def test_invalid_archive_environment_variable_is_not_ignored(tmp_path, monkeypatch):
+    missing = tmp_path / "missing.zarr"
+    monkeypatch.setenv(DCTConfig.ARCHIVE_ENV_VAR, str(missing))
+    with pytest.raises(FileNotFoundError, match=DCTConfig.ARCHIVE_ENV_VAR):
+        DCTConfig()
+
+
 def test_patch_dataset_can_emit_archive_backed_canonical_batch(tmp_path):
     archive_path = _make_archive(tmp_path)
     config = DCTConfig(zarr_path=archive_path)
@@ -943,3 +967,25 @@ def test_checkpoint_with_matching_ct2idx_and_canonical_channels_is_accepted():
         "canonical_channels": list(config.marker2idx.keys()),
     }
     validate_checkpoint_vocabulary(ckpt, config.ct2idx, config.marker2idx)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("n_heads", True, "positive integer"),
+        ("n_heads", 2.5, "positive integer"),
+        ("n_heads", 0, "positive integer"),
+        ("compat_marker0_zero", "false", "must be a boolean"),
+        ("compat_marker0_zero", 1, "must be a boolean"),
+    ],
+)
+def test_build_model_rejects_invalid_architecture_config(
+    tmp_path, field, value, message
+):
+    config = DCTConfig()
+    checkpoint = torch.load(
+        _build_checkpoint(config, tmp_path), map_location="cpu", weights_only=True
+    )
+    checkpoint["config"][field] = value
+    with pytest.raises(ValueError, match=message):
+        _build_model(checkpoint, config, torch.device("cpu"))

--- a/tests/test_centroid_tolerance.py
+++ b/tests/test_centroid_tolerance.py
@@ -1,12 +1,16 @@
 """Unit tests for centroid_to_cell_idx_fast tolerance behavior.
 
-Round-2 audit found 4 mcmicro_TMA11 FOVs losing 38-40% of cells at tol=1.0
+Some mcmicro_TMA11 FOVs lose 38-40% of cells at tol=1.0
 because of sub-pixel drift between standardized_source centroids and
 preprocessed centroids amplified by scale_factor=1.3. Default tolerance was
 bumped to 1.5 to recover those cells. These tests pin the behavior at both
 tolerance values so the bump can't be reverted accidentally.
 """
-from deepcell_types.training.annotations import build_centroid_tree, centroid_to_cell_idx_fast
+
+from deepcell_types.training.annotations import (
+    build_centroid_tree,
+    centroid_to_cell_idx_fast,
+)
 
 
 def _tree_from(centroids):

--- a/tests/test_dataloader_integration.py
+++ b/tests/test_dataloader_integration.py
@@ -85,6 +85,25 @@ def test_config_reads_training_archive_contract(archive_and_config):
     assert config.tissue2idx == {"liver": 0, "lung": 1}
 
 
+def test_tissuenet_config_rejects_noncontiguous_cell_type_mapping(tmp_path):
+    archive_path = tmp_path / "bad.zarr"
+    root = zarr.open_group(str(archive_path), mode="w")
+    root.attrs["cell_type_mapping"] = {"Bcell": 0, "Tumor": 2}  # gap at index 1
+    root.attrs["all_standardized_channels"] = ["CD45"]
+    with pytest.raises(ValueError, match="unique and contiguous"):
+        TissueNetConfig(archive_path)
+
+
+def test_tissuenet_config_rejects_missing_cell_type_mapping(tmp_path):
+    # An archive missing cell_type_mapping must fail loudly, not default to an
+    # empty mapping that passes the contiguity check vacuously (NUM_CELLTYPES=0).
+    archive_path = tmp_path / "empty.zarr"
+    root = zarr.open_group(str(archive_path), mode="w")
+    root.attrs["all_standardized_channels"] = ["CD45"]
+    with pytest.raises(ValueError, match="missing root attrs.cell_type_mapping"):
+        TissueNetConfig(archive_path)
+
+
 def test_full_image_dataset_indexes_all_cells(archive_and_config):
     archive_path, config = archive_and_config
     dataset = FullImageDataset(archive_path, dct_config=config)

--- a/tests/test_dataset_cache.py
+++ b/tests/test_dataset_cache.py
@@ -4,6 +4,8 @@ import json
 import os
 import pickle
 
+import pytest
+
 from deepcell_types.training import config as config_module
 from deepcell_types.training.config import (
     archive_array_fingerprint,
@@ -109,6 +111,22 @@ def test_cell_data_cache_rejects_group_writable_file(tmp_path):
     assert os.stat(cache_path).st_mode & 0o020
 
 
+def test_cell_data_cache_rejects_symlink(tmp_path):
+    # The cache path is predictable, so an attacker on a shared filesystem could
+    # replace it with a symlink to a crafted pickle they control. O_NOFOLLOW
+    # must refuse to follow the link and trigger a rebuild instead.
+    real = tmp_path / "attacker.pkl"
+    FullImageDataset._save_cell_data_cache(real, {"labeled": {}}, "archive123")
+    cache_path = tmp_path / "cell-data.pkl"
+    os.symlink(real, cache_path)
+
+    loaded = FullImageDataset._load_cell_data_cache(
+        cache_path, ["labeled"], "archive123"
+    )
+
+    assert loaded is None
+
+
 def test_cell_data_cache_rebuilds_on_stale_import_error(tmp_path, monkeypatch):
     cache_path = tmp_path / "cell-data.pkl"
     cache_path.write_bytes(b"placeholder")
@@ -121,6 +139,20 @@ def test_cell_data_cache_rebuilds_on_stale_import_error(tmp_path, monkeypatch):
         FullImageDataset._load_cell_data_cache(cache_path, ["labeled"], "archive123")
         is None
     )
+
+
+def test_validate_cell_data_lengths_rejects_mismatch():
+    # cell_types / cell_indices / centroids of differing lengths would silently
+    # misalign labels with cells; the loader must reject it.
+    with pytest.raises(ValueError, match="must have equal lengths"):
+        FullImageDataset._validate_cell_data_lengths(
+            "ds1", (["CD4T", "CD8T"], [1], [[0.0, 0.0], [1.0, 1.0]])
+        )
+
+
+def test_validate_cell_data_lengths_accepts_equal():
+    triple = (["CD4T"], [1], [[0.0, 0.0]])
+    assert FullImageDataset._validate_cell_data_lengths("ds1", triple) == triple
 
 
 def _write_json(path, payload):

--- a/tests/test_dataset_cache.py
+++ b/tests/test_dataset_cache.py
@@ -1,6 +1,7 @@
 """Tests for zarr cell-data cache provenance and negative entries."""
 
 import json
+import os
 import pickle
 
 from deepcell_types.training import config as config_module
@@ -93,6 +94,33 @@ def test_cell_data_cache_rejects_legacy_bare_dict(tmp_path):
     )
 
     assert loaded is None
+
+
+def test_cell_data_cache_rejects_group_writable_file(tmp_path):
+    cache_path = tmp_path / "cell-data.pkl"
+    FullImageDataset._save_cell_data_cache(cache_path, {"labeled": {}}, "archive123")
+    cache_path.chmod(0o660)
+
+    loaded = FullImageDataset._load_cell_data_cache(
+        cache_path, ["labeled"], "archive123"
+    )
+
+    assert loaded is None
+    assert os.stat(cache_path).st_mode & 0o020
+
+
+def test_cell_data_cache_rebuilds_on_stale_import_error(tmp_path, monkeypatch):
+    cache_path = tmp_path / "cell-data.pkl"
+    cache_path.write_bytes(b"placeholder")
+
+    def fail_load(_file):
+        raise ModuleNotFoundError("removed cache class")
+
+    monkeypatch.setattr(pickle, "load", fail_load)
+    assert (
+        FullImageDataset._load_cell_data_cache(cache_path, ["labeled"], "archive123")
+        is None
+    )
 
 
 def _write_json(path, payload):

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -1,12 +1,12 @@
 """Tests for deepcell_types.training.losses.
 
-R7 M4 — FocalLoss coverage:
+FocalLoss coverage:
     (a) reduction='none' shape
     (b) reduction='sum' matches sum of 'none'
     (c) ignore_index correctly excludes samples
     (d) gamma=0, alpha=None reduces to F.cross_entropy
 
-R7 M5 — HierarchicalLoss coverage:
+HierarchicalLoss coverage:
     (a) parent-superclass-wrong-leaf case: hierarchical loss is lower than flat CE
     (b) smoke test on project CELL_TYPE_HIERARCHY → finite scalar
 """
@@ -19,7 +19,7 @@ from deepcell_types.training.losses import FocalLoss, HierarchicalLoss
 
 
 # =============================================================================
-# R7 M4 — FocalLoss coverage
+# FocalLoss coverage
 # =============================================================================
 
 
@@ -120,7 +120,7 @@ class TestFocalLossReduction:
 
 
 # =============================================================================
-# R7 M5 — HierarchicalLoss
+# HierarchicalLoss coverage
 # =============================================================================
 
 
@@ -134,6 +134,7 @@ def tiny_hierarchy_yaml(tmp_path):
         Macrophage       → Myeloid
     """
     import yaml
+
     mapping = {
         "CD4T": "Tcell",
         "CD8T": "Tcell",
@@ -149,7 +150,9 @@ def tiny_hierarchy_yaml(tmp_path):
 
 
 class TestHierarchicalLoss:
-    def test_parent_superclass_wrong_leaf_is_lower_than_flat_ce(self, tiny_hierarchy_yaml):
+    def test_parent_superclass_wrong_leaf_is_lower_than_flat_ce(
+        self, tiny_hierarchy_yaml
+    ):
         """If the prediction lands on the wrong leaf but right parent group,
         hierarchical loss < flat cross-entropy.
 
@@ -203,6 +206,7 @@ class TestHierarchicalLoss:
 
         # Construct a minimal ct2idx that matches the YAML keys.
         import yaml
+
         with open(yaml_path) as f:
             mapping = yaml.safe_load(f)
         fine_names = sorted(mapping.keys())

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -187,6 +187,20 @@ def test_preprocess_fov_rejects_shape_mismatches():
         )
 
 
+@pytest.mark.parametrize("name", ["native_mpp", "target_mpp"])
+@pytest.mark.parametrize("value", [0.0, -1.0, float("nan"), float("inf")])
+def test_preprocess_fov_rejects_invalid_resolution(name, value):
+    kwargs = {"native_mpp": 0.5, "target_mpp": 0.5}
+    kwargs[name] = value
+    with pytest.raises(ValueError, match=f"{name} must be positive and finite"):
+        preprocess_fov(
+            np.ones((1, 2, 2), dtype=np.float32),
+            np.ones((2, 2), dtype=np.int32),
+            channel_names=["CD3"],
+            **kwargs,
+        )
+
+
 def test_preprocess_fov_deterministic():
     raw, mask = _fixture_raw_mask()
     out1 = preprocess_fov(

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -55,7 +55,7 @@ def test_percentile_threshold_handles_all_zero_channel():
 def test_percentile_threshold_excludes_zeros_from_calculation():
     # If zeros were included, p99.9 would be near 0 and everything clipped.
     arr = np.zeros((100, 100, 1), dtype=np.float32)
-    arr[:5, :5, 0] = 100.0   # 25 nonzero pixels at value 100
+    arr[:5, :5, 0] = 100.0  # 25 nonzero pixels at value 100
     out = _percentile_threshold(arr, percentile=99.9)
     # Threshold from nonzero pixels = 100, so 100s should remain 100
     assert (out[:5, :5, 0] == 100.0).all()
@@ -64,9 +64,9 @@ def test_percentile_threshold_excludes_zeros_from_calculation():
 
 
 def test_min_max_normalize_to_unit_range():
-    arr = np.array([[[2.0, 5.0]],
-                    [[4.0, 5.0]],
-                    [[6.0, 5.0]]], dtype=np.float32)  # (3, 1, 2)
+    arr = np.array(
+        [[[2.0, 5.0]], [[4.0, 5.0]], [[6.0, 5.0]]], dtype=np.float32
+    )  # (3, 1, 2)
     out = _min_max_normalize(arr)
     # Channel 0: min=2, max=6 → normalized to {0, 0.5, 1}
     np.testing.assert_allclose(out[..., 0].ravel(), [0.0, 0.5, 1.0])
@@ -91,9 +91,7 @@ def _fixture_raw_mask(C=3, H=20, W=20):
 
 def test_preprocess_fov_output_in_unit_range_and_correct_dtypes():
     raw, mask = _fixture_raw_mask()
-    out = preprocess_fov(
-        raw, mask, native_mpp=0.5, channel_names=["A", "B", "C"]
-    )
+    out = preprocess_fov(raw, mask, native_mpp=0.5, channel_names=["A", "B", "C"])
     assert isinstance(out, PreprocessedFov)
     assert out.raw.dtype == np.float32
     assert out.mask.dtype == np.uint32
@@ -107,18 +105,14 @@ def test_preprocess_fov_produces_max_one_per_channel():
     """The recipe normalizes to [0, 1] per channel, so each channel's
     max should be exactly 1.0 (matches production)."""
     raw, mask = _fixture_raw_mask()
-    out = preprocess_fov(
-        raw, mask, native_mpp=0.5, channel_names=["A", "B", "C"]
-    )
+    out = preprocess_fov(raw, mask, native_mpp=0.5, channel_names=["A", "B", "C"])
     perch_max = out.raw.max(axis=(1, 2))
     np.testing.assert_allclose(perch_max, 1.0, atol=1e-6)
 
 
 def test_preprocess_fov_resamples_to_target_mpp():
     raw, mask = _fixture_raw_mask()
-    out = preprocess_fov(
-        raw, mask, native_mpp=1.0, channel_names=["x", "y", "z"]
-    )
+    out = preprocess_fov(raw, mask, native_mpp=1.0, channel_names=["x", "y", "z"])
     # native=1.0, target=0.5 → upsample 2x
     assert out.scale_factor == pytest.approx(2.0)
     assert out.raw.shape[1] == 40
@@ -127,9 +121,7 @@ def test_preprocess_fov_resamples_to_target_mpp():
 
 def test_preprocess_fov_no_resample_when_mpp_matches():
     raw, mask = _fixture_raw_mask()
-    out = preprocess_fov(
-        raw, mask, native_mpp=0.5, channel_names=["a", "b", "c"]
-    )
+    out = preprocess_fov(raw, mask, native_mpp=0.5, channel_names=["a", "b", "c"])
     assert out.scale_factor == pytest.approx(1.0)
     assert out.raw.shape == raw.shape
     assert out.mask.shape == mask.shape
@@ -137,9 +129,7 @@ def test_preprocess_fov_no_resample_when_mpp_matches():
 
 def test_preprocess_fov_centroids_match_resampled_mask():
     raw, mask = _fixture_raw_mask()
-    out = preprocess_fov(
-        raw, mask, native_mpp=0.5, channel_names=["a", "b", "c"]
-    )
+    out = preprocess_fov(raw, mask, native_mpp=0.5, channel_names=["a", "b", "c"])
     assert "1" in out.centroids
     r, c = out.centroids["1"]
     # Cell 1 occupies rows 5..10, cols 5..10
@@ -152,9 +142,7 @@ def test_preprocess_fov_handles_all_zero_channel():
     raw[0] = 5.0  # channel 0 has signal
     # channel 1 is all zero
     mask = np.zeros((8, 8), dtype=np.int32)
-    out = preprocess_fov(
-        raw, mask, native_mpp=0.5, channel_names=["A", "B"]
-    )
+    out = preprocess_fov(raw, mask, native_mpp=0.5, channel_names=["A", "B"])
     # Channel 0: signal (constant 5) gets clipped + min-max → 0
     # because min == max → ptp=0 → output is 0
     assert (out.raw[1] == 0.0).all()
@@ -165,26 +153,20 @@ def test_preprocess_fov_rejects_shape_mismatches():
     mask = np.zeros((8, 8), dtype=np.int32)
 
     with pytest.raises(ValueError, match="raw must be"):
-        preprocess_fov(
-            raw[0], mask, native_mpp=0.5, channel_names=["x"]
-        )
+        preprocess_fov(raw[0], mask, native_mpp=0.5, channel_names=["x"])
     with pytest.raises(ValueError, match="mask must be"):
-        preprocess_fov(
-            raw, mask[None], native_mpp=0.5, channel_names=["a", "b", "c"]
-        )
+        preprocess_fov(raw, mask[None], native_mpp=0.5, channel_names=["a", "b", "c"])
     with pytest.raises(ValueError, match="raw spatial"):
         preprocess_fov(
-            raw, np.zeros((4, 4), dtype=np.int32), native_mpp=0.5,
-            channel_names=["a", "b", "c"]
+            raw,
+            np.zeros((4, 4), dtype=np.int32),
+            native_mpp=0.5,
+            channel_names=["a", "b", "c"],
         )
     with pytest.raises(ValueError, match=r"len\(channel_names\)"):
-        preprocess_fov(
-            raw, mask, native_mpp=0.5, channel_names=["only-two", "names"]
-        )
+        preprocess_fov(raw, mask, native_mpp=0.5, channel_names=["only-two", "names"])
     with pytest.raises(ValueError, match="native_mpp must be positive"):
-        preprocess_fov(
-            raw, mask, native_mpp=0.0, channel_names=["a", "b", "c"]
-        )
+        preprocess_fov(raw, mask, native_mpp=0.0, channel_names=["a", "b", "c"])
 
 
 @pytest.mark.parametrize("name", ["native_mpp", "target_mpp"])
@@ -203,12 +185,8 @@ def test_preprocess_fov_rejects_invalid_resolution(name, value):
 
 def test_preprocess_fov_deterministic():
     raw, mask = _fixture_raw_mask()
-    out1 = preprocess_fov(
-        raw, mask, native_mpp=0.7, channel_names=["a", "b", "c"]
-    )
-    out2 = preprocess_fov(
-        raw, mask, native_mpp=0.7, channel_names=["a", "b", "c"]
-    )
+    out1 = preprocess_fov(raw, mask, native_mpp=0.7, channel_names=["a", "b", "c"])
+    out2 = preprocess_fov(raw, mask, native_mpp=0.7, channel_names=["a", "b", "c"])
     np.testing.assert_array_equal(out1.raw, out2.raw)
     np.testing.assert_array_equal(out1.mask, out2.mask)
     assert out1.centroids == out2.centroids
@@ -240,6 +218,7 @@ def test_snapshot_against_production():
     max per-channel mean drift on HBM222 ≈ 0.046, so we assert < 0.06.
     """
     import zarr
+
     z = zarr.open(PRODUCTION_ARCHIVE, mode="r")
     if SNAPSHOT_DATASET not in z:
         pytest.skip(f"{SNAPSHOT_DATASET} not in production archive")
@@ -250,9 +229,7 @@ def test_snapshot_against_production():
     img = g["image"]
     pp = g["preprocessed/raw"]
     native_mpp = float(img.attrs.get("mpp", 0.5))
-    ch_raw = list(
-        img.attrs.get("standardized_channels", img.attrs.get("channels", []))
-    )
+    ch_raw = list(img.attrs.get("standardized_channels", img.attrs.get("channels", [])))
     ch_pp = list(g["preprocessed"].attrs.get("channel_names", []))
     if not ch_raw or not ch_pp:
         pytest.skip(f"{SNAPSHOT_DATASET} missing channel attrs")
@@ -268,8 +245,10 @@ def test_snapshot_against_production():
 
     fake_mask = np.zeros(selected_raw.shape[1:], dtype=np.int32)
     out = preprocess_fov(
-        selected_raw, fake_mask,
-        native_mpp=native_mpp, channel_names=selected_channels,
+        selected_raw,
+        fake_mask,
+        native_mpp=native_mpp,
+        channel_names=selected_channels,
     )
 
     # Bound 1: shape matches within ±1 pixel.
@@ -306,5 +285,5 @@ def test_snapshot_against_production():
     # Bound 4: ≥85% of pixels match within 1e-2 (resampling boundary).
     pixel_match = (np.abs(ours - prod) < 1e-2).mean()
     assert pixel_match > 0.85, (
-        f"only {pixel_match*100:.1f}% of pixels match within 1e-2"
+        f"only {pixel_match * 100:.1f}% of pixels match within 1e-2"
     )

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -183,6 +183,19 @@ def test_preprocess_fov_rejects_invalid_resolution(name, value):
         )
 
 
+@pytest.mark.parametrize("value", [-1.0, 101.0, float("nan"), float("inf")])
+def test_preprocess_fov_rejects_invalid_percentile(value):
+    with pytest.raises(ValueError, match="percentile must be finite and in"):
+        preprocess_fov(
+            np.ones((1, 2, 2), dtype=np.float32),
+            np.ones((2, 2), dtype=np.int32),
+            channel_names=["CD3"],
+            native_mpp=0.5,
+            target_mpp=0.5,
+            percentile=value,
+        )
+
+
 def test_preprocess_fov_deterministic():
     raw, mask = _fixture_raw_mask()
     out1 = preprocess_fov(raw, mask, native_mpp=0.7, channel_names=["a", "b", "c"])

--- a/tests/test_preprocessing_ops.py
+++ b/tests/test_preprocessing_ops.py
@@ -101,7 +101,8 @@ def test_background_subtract_per_channel_can_target_named_channel():
     x += 1000.0  # both channels on a pedestal
     names = ["CD15", "CD8"]
     out = apply_config(
-        x, names,
+        x,
+        names,
         [{"op": "background_subtract_per_channel", "p": 50.0, "names": ["CD15"]}],
     )
     # only CD15 is corrected; CD8 is untouched

--- a/tests/test_preprocessing_ops.py
+++ b/tests/test_preprocessing_ops.py
@@ -44,6 +44,19 @@ def test_channel_drop_zeros_named_channel():
     assert np.all(out[2] == 0.0)
 
 
+@pytest.mark.parametrize(
+    "step",
+    [
+        {"op": "background_subtract_per_channel", "names": ["TYPO"]},
+        {"op": "channel_drop", "names": ["TYPO"]},
+        {"op": "channel_weight", "weights": {"TYPO": 0.5}},
+    ],
+)
+def test_named_ops_reject_unknown_channels(step):
+    with pytest.raises(ValueError, match="unknown preprocessing channel"):
+        apply_config(np.ones((1, 2, 2)), ["CD3"], [step])
+
+
 def test_channel_weight_after_normalize_scales():
     raw, names = _fov()
     cfg = [

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -1,4 +1,4 @@
-"""Tests for FOVGroupedSampler (R7 L1) and LazyMarkerPositivityDict (R7 L2)."""
+"""Tests for FOVGroupedSampler and LazyMarkerPositivityDict."""
 
 import pickle
 
@@ -15,7 +15,7 @@ from deepcell_types.training.dataset import (
 
 
 # =============================================================================
-# R7 L1 — FOVGroupedSampler: cells from the same FOV must stay batched together
+# FOVGroupedSampler: cells from the same FOV must stay batched together
 # =============================================================================
 
 
@@ -268,7 +268,7 @@ class TestSequentialFOVGroupedSampler:
 
 
 # =============================================================================
-# R7 L2 — LazyMarkerPositivityDict: lazy load semantics
+# LazyMarkerPositivityDict: lazy load semantics
 # =============================================================================
 
 

--- a/tests/test_zero_channel_masking.py
+++ b/tests/test_zero_channel_masking.py
@@ -1,6 +1,6 @@
 """Unit tests for FOV-zero-channel masking in FullImageDataset.__getitem__.
 
-Round-1 audit found ~3.4% of valid channels per MIBI/IMC FOV are listed in
+About 3.4% of valid channels per MIBI/IMC FOV are listed in
 channel_names but all-zero in raw across the entire FOV. These channels were
 fed to the transformer as constant-zero tokens with a misleading marker
 embedding prior. The fix masks them out at FOV-time. These tests verify the
@@ -14,6 +14,7 @@ anchors the test file to a concrete substring in the real code; if the
 production masking is refactored, that anchor will fail loudly so the copy
 here can be updated (or this test file deleted) deliberately.
 """
+
 from pathlib import Path
 
 import numpy as np
@@ -30,7 +31,9 @@ class _MinimalDataset:
         self._zero_channel_cache = {}
 
 
-def _apply_zero_channel_mask(ds, ds_idx, n_real_channels, ch_idx, sample, mp_padded, vm_padded):
+def _apply_zero_channel_mask(
+    ds, ds_idx, n_real_channels, ch_idx, sample, mp_padded, vm_padded
+):
     """Replicates the masking block from dataset.py::__getitem__ for unit testing."""
     attn_mask = np.ones(ds.max_channels, dtype=bool)
     attn_mask[:n_real_channels] = ch_idx[:n_real_channels] == -1
@@ -62,7 +65,9 @@ def test_all_zero_channel_is_masked_in_attn_mask():
     mp = np.ones(ds.max_channels, dtype=np.float32)
     vm = np.ones(ds.max_channels, dtype=bool)
 
-    attn_mask, sample, mp, vm = _apply_zero_channel_mask(ds, 0, 3, ch_idx, sample, mp, vm)
+    attn_mask, sample, mp, vm = _apply_zero_channel_mask(
+        ds, 0, 3, ch_idx, sample, mp, vm
+    )
     # Channel 1 was all-zero -> attn_mask True (padded out)
     assert not attn_mask[0]
     assert attn_mask[1]
@@ -105,7 +110,9 @@ def test_no_zero_cache_means_no_extra_masking():
     mp = np.ones(ds.max_channels, dtype=np.float32)
     vm = np.ones(ds.max_channels, dtype=bool)
 
-    attn_mask, sample, mp, vm = _apply_zero_channel_mask(ds, 0, 3, ch_idx, sample, mp, vm)
+    attn_mask, sample, mp, vm = _apply_zero_channel_mask(
+        ds, 0, 3, ch_idx, sample, mp, vm
+    )
     # Only the unknown channel is masked
     assert not attn_mask[0]
     assert attn_mask[1]  # ch_idx == -1
@@ -145,7 +152,9 @@ def test_combined_unknown_and_zero_channel():
     mp = np.ones(ds.max_channels, dtype=np.float32)
     vm = np.ones(ds.max_channels, dtype=bool)
 
-    attn_mask, sample, mp, vm = _apply_zero_channel_mask(ds, 0, 3, ch_idx, sample, mp, vm)
+    attn_mask, sample, mp, vm = _apply_zero_channel_mask(
+        ds, 0, 3, ch_idx, sample, mp, vm
+    )
     assert not attn_mask[0]
     assert attn_mask[1]  # unknown
     assert attn_mask[2]  # zero


### PR DESCRIPTION
## Summary

This draft addresses the actionable release-readiness findings from the deep review of upstream `master`, excluding the license inconsistency and the existing inference-only CI collection failure by request.

### User workflows and documentation

- Make the inference quick start self-contained and document structured results.
- Clarify the released checkpoint/archive marker compatibility contract.
- Document training and baseline commands as source-checkout workflows with complete examples.
- Lead preprocessing guidance with the Python API and present the agent skill as optional automation.
- Remove missing tutorial-image references, unsupported numeric claims, and internal review/history labels.
- Default training/evaluation scripts to automatic CUDA/CPU selection.

### Runtime and scientific contracts

- Validate contiguous cell-type indices, checkpoint architecture fields, MPP values, annotation lengths, and named preprocessing channels.
- Make configuration mappings read-only and eliminate stale archive metadata caching.
- Apply the same strict checkpoint validation to Python and archive-evaluation entry points.
- Batch MAPS validation, honor the selected XGBoost tuning metric, and fail Nimbus runs that produce no predictions.

### Artifact and cache safety

- Use restricted checkpoint loading in release repackaging.
- Replace pickle-enabled marker-order NPZ input with JSON.
- Make downloads bounded, atomic, integrity-checked, and non-destructive to valid cached files.
- Bound archive extraction and reject special members.
- Validate pickle caches on the opened descriptor, reject group/world-writable files, and rebuild corrupt caches safely.
- Reject invalid `DEEPCELL_TYPES_ZARR_PATH` values instead of silently falling back.

## User/developer impact

Users get runnable onboarding, clearer installed-versus-source workflows, safer artifact handling, CPU-friendly CLI defaults, and decisive errors for inputs that could otherwise silently alter scientific results. Maintainers get regression coverage for these contracts and release-facing comments that explain current intent rather than review history.

## Validation

- `UV_FROZEN=0 uv run pytest -q` — **445 passed, 3 skipped**
- `UV_FROZEN=0 uv run ruff check .` — passed
- Ruff format check for all changed Python files — passed
- Wheel build — passed
- Clean-environment wheel install/import smoke — passed
- Static Sphinx build with warnings treated as errors — passed
- `git diff --check` — passed

The executable tutorial requires authenticated model/data access and was not run without credentials.

## Intentionally excluded

- License text/metadata inconsistency
- Existing inference-only CI collection failure

## Remaining decisions / evidence gaps

- The repository does not contain an authoritative SHA-256 or exact byte size for `public_data_v1.1.zip`; this PR does not invent those publisher values.
- Exact epoch-wide AUROC/threshold metrics still retain scores because bounding them would change the scientific metric contract.
- Probability retention and multi-worker preprocessing need an explicit API/performance design.
- Deterministic CellSighter spawned-worker shutdown needs a production-like integration harness.
- A repository-wide dependency lock/constraints and container-digest policy remains a separate release-policy decision.
