### PR TITLE
Default ct_abstention_k=0 (opt-in) + docs cleanup

### DIFF
--- a/deepcell_types/abstention.py
+++ b/deepcell_types/abstention.py
@@ -21,7 +21,7 @@ Operating points:
   an earlier-draft operating point that widened macro_F1 separation over the
   strongest baseline on kept cells. IQR-fence abstention was dropped from the
   paper, whose headline is full-coverage with no abstention; ``predict()``'s
-  default is ``None`` (abstention off).
+  default is ``0`` (abstention off).
 * ``k = 1.5`` (canonical Tukey): near-no-op (~0.23% abstained,
   +0.02pp macro).
 * ``k <= 0``: callers skip abstention. (Passing ``k = 0`` to

--- a/deepcell_types/predict.py
+++ b/deepcell_types/predict.py
@@ -351,7 +351,7 @@ def predict(
     num_workers=0,
     zarr_path=None,
     return_probabilities=False,
-    ct_abstention_k=None,
+    ct_abstention_k=0,
     preprocess=None,
 ) -> "list[str] | PredictionResult":
     """Run the cell-type prediction pipeline.
@@ -403,17 +403,17 @@ def predict(
         If False (default, back-compat), returns a list of cell-type names.
         If True, returns a :class:`PredictionResult` with the full per-cell
         softmax probability matrix and the cell indices.
-    ct_abstention_k : float or None, default=None
+    ct_abstention_k : float, default=0
         IQR-fence post-hoc abstention multiplier. Abstention is **opt-in**:
-        the default ``None`` returns the raw argmax cell-type label for every
-        cell and never relabels to ``"Unknown"``. When set to a float, the
-        fence is ``Q1 - k*IQR`` on the per-FOV cell-wise max-softmax
-        distribution and cells below it are relabelled to ``"Unknown"``
-        (``k=0.2`` is a historical opt-in ablation; the paper headline is
-        full-coverage with no abstention). Pass ``return_probabilities=True``
-        to recover the pre-abstention labels and the ``abstained`` mask. Has
-        no effect on FOVs with fewer than 4 cells
-        (the IQR is undefined).
+        the default ``0`` (any ``k <= 0``) returns the raw argmax cell-type
+        label for every cell and never relabels to ``"Unknown"``. Pass a
+        positive float to enable it: the fence is ``Q1 - k*IQR`` on the
+        per-FOV cell-wise max-softmax distribution and cells below it are
+        relabelled to ``"Unknown"`` (``k=0.2`` is a historical opt-in
+        ablation; the paper headline is full-coverage with no abstention).
+        Pass ``return_probabilities=True`` to recover the pre-abstention
+        labels and the ``abstained`` mask. Has no effect on FOVs with fewer
+        than 4 cells (the IQR is undefined).
     preprocess : callable, optional, default=None
         Custom per-FOV preprocessing hook. Called as
         ``preprocess(raw, channel_names) -> raw`` where ``raw`` is a
@@ -433,7 +433,7 @@ def predict(
         (default) Predicted cell-type name for each unique cell index in
         ``mask``, ordered by ascending cell index. Cells flagged by the
         IQR-fence abstention carry the sentinel ``"Unknown"`` — but only
-        when ``ct_abstention_k`` is set; with the default ``None`` every
+        when ``ct_abstention_k > 0``; with the default ``0`` every
         cell carries its raw argmax label.
     PredictionResult
         (when ``return_probabilities=True``) Full per-cell probabilities,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,9 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # Execution conf
 nb_execution_timeout = 300  # seconds
 nb_execution_show_tb = True  # print tracebacks to stderr
+# Drop stderr (warnings, tqdm progress bars, build-machine file paths) from the
+# rendered cell output — the tutorial's meaningful output is all stdout/display.
+nb_output_stderr = "remove"
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,35 +34,6 @@ from deepcell_types.utils import download_model
 download_model()  # No argument == latest released version
 ```
 
-## TissueNet archive (optional)
-
-`predict()` does **not** require the TissueNet archive: the marker / cell-type
-registry it needs ships with the package as a small `vocab.json` snapshot, so
-the base install above + `download_model()` is enough to run inference.
-
-The (multi-GB) `tissuenet-v*.zarr` archive is only needed if you want the
-tissue→cell-type mapping or are reproducing the training pipeline. It is
-distributed as a `.zip` that must be extracted before use:
-
-```python
-from deepcell_types.utils import download_training_data
-
-# Downloads the .zip and extracts it; returns the extraction directory
-# containing the tissuenet-v*.zarr archive. (Large download — see API-key page.)
-archive_dir = download_training_data(extract=True)
-```
-
-When you do have an archive, point `predict` at it with the `zarr_path=`
-argument, or set it once for the session:
-
-```bash
-export DEEPCELL_TYPES_ZARR_PATH=/path/to/tissuenet-v10.zarr
-```
-
-An explicit `zarr_path=` that doesn't contain an archive raises
-`FileNotFoundError`; the checkpoint and registry must agree on the marker and
-cell-type ordering, otherwise loading fails early with a `ValueError`.
-
 ## Running
 
 The {doc}`site/tutorial` demonstrates how to set up, run, and visualize the
@@ -171,16 +142,13 @@ using `scripts/...`; see the README's Training section for complete commands.
 
 The end-to-end training and evaluation scripts live under `scripts/`:
 
-- `scripts/train.py` — main training entry point (DCTConfig + FullImageDataset
-  + FocalLoss / HierarchicalLoss + OneCycleLR; supports the FOV-grouped
-  sampler and the conditioned marker-positivity head).
+- `scripts/train.py` — main training entry point.
 - `scripts/predict.py` — batched predictions over a zarr archive, with
   optional hierarchy-aware evaluation.
 - `scripts/pretrain.py` — masked-marker pretraining stage.
 
 All training scripts read mappings and metadata from a TissueNet zarr v3
-archive (`tissuenet-v10.zarr` is the current canonical release; v8 and v9
-are also accepted). Pass the archive path with
+archive (`expanded-tissuenet.zarr`). Pass the archive path with
 `--zarr_dir` (training scripts) or via the `DEEPCELL_TYPES_ZARR_PATH`
 environment variable (`deepcell_types.predict`).
 

--- a/docs/site/tutorial.md
+++ b/docs/site/tutorial.md
@@ -319,8 +319,8 @@ mapping explicit:
 
 ```{note}
 **Low-confidence abstention.** Abstention is opt-in. By default
-(`ct_abstention_k=None`) `predict` returns the raw argmax label for *every*
-cell. To enable it, pass a float `k`: `predict` then flags cells whose
+(`ct_abstention_k=0`) `predict` returns the raw argmax label for *every*
+cell. To enable it, pass a positive float `k`: `predict` then flags cells whose
 top-class probability falls below an IQR fence on the field-of-view's
 confidence distribution and rewrites their label to the sentinel `"Unknown"`.
 Reported results use full coverage (no abstention). The following example shows

--- a/tests/test_canonical_inference.py
+++ b/tests/test_canonical_inference.py
@@ -667,7 +667,7 @@ def test_predict_empty_mask_returns_empty(tmp_path):
 
 
 def test_predict_default_does_not_abstain(tmp_path):
-    """Abstention is opt-in: with the default ``ct_abstention_k=None`` no cell
+    """Abstention is opt-in: with the default ``ct_abstention_k=0`` no cell
     is relabelled to the sentinel and the returned labels equal the raw argmax
     labels. Guards against silently re-enabling the benchmark-tuned default."""
     import inspect
@@ -678,7 +678,7 @@ def test_predict_default_does_not_abstain(tmp_path):
     # uniform input whose max-softmax distribution never trips the IQR fence
     # (so they hold for any ``k``), so this signature check is what actually
     # catches a regression back to the old benchmark-tuned ``ct_abstention_k=0.2``.
-    assert inspect.signature(predict).parameters["ct_abstention_k"].default is None
+    assert inspect.signature(predict).parameters["ct_abstention_k"].default == 0
 
     torch.manual_seed(0)
     archive_path = _make_archive(tmp_path)


### PR DESCRIPTION
Ports the polish already merged on the fork (xuefei-wang#76) to upstream. Two commits, minimal diff.

## refactor(api): default `ct_abstention_k=0` (opt-in), matching the CLI
`predict()` now defaults `ct_abstention_k` to `0` instead of `None`.
Behavior-preserving — the gate is `k > 0`, so `None` and `0` both mean "no
abstention" — but `0` is now the documented off sentinel and the Python API
matches `scripts/predict.py`, whose `--ct_abstention_k` already defaults to
`0`. Abstention stays fully opt-in: pass a positive `k` to enable the per-FOV
IQR fence. Docstrings, the signature-default test, and the tutorial note updated.

## docs: strip stderr from tutorial output + trim index page
- **conf.py**: `nb_output_stderr = "remove"` so executed tutorial output never
  renders build-machine file paths, `Can't initialize NVML` warnings, tqdm
  bars, or the masked-channel `UserWarning`.
- **index.md**: drop the "TissueNet archive (optional)" section (covered on the
  Model and Datasets page), drop the `scripts/train.py` internals parenthetical,
  and replace the `tissuenet-v8/v9/v10` version terms with `expanded-tissuenet.zarr`.

Cherry-picked cleanly onto current `master`; `test_canonical_inference.py`
abstention tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)