### PR TITLE
docs(tutorial): restore the napari screenshot cells and result images

### DIFF
--- a/docs/site/tutorial.md
+++ b/docs/site/tutorial.md
@@ -247,8 +247,26 @@ mask_lyr = nim.add_labels(mask, name="CellSAM segmentation")
 mask_lyr.contour = 3  # Relatively thick borders for static viz
 ```
 
-The image and segmentation layers appear directly in the interactive Napari
-viewer. Static documentation builds do not execute or embed GUI screenshots.
+```{code-cell} ipython3
+:tags: [hide-cell]
+
+# For static rendering - can safely be ignored if running notebook interactively
+from pathlib import Path
+
+screenshot_path = Path("../_static/_generated")
+screenshot_path.mkdir(parents=True, exist_ok=True)
+nim.screenshot(
+    path=screenshot_path / "napari_img_and_segmentation.png",
+    canvas_only=False,
+);
+```
+
+<center>
+  <img src="../_static/_generated/napari_img_and_segmentation.png"
+       alt="Napari window of multiplexed image and computed segmentation mask"
+       width=100%
+  />
+</center>
 
 
 ### Cell-type inference with `deepcell-types`
@@ -401,9 +419,26 @@ for k, l in labels_by_celltype.items():
     )
 ```
 
-When running interactively, the new label layers appear directly in the Napari
-viewer and can be toggled independently. Static documentation builds do not
-execute or embed GUI screenshots.
+```{code-cell} ipython3
+:tags: [hide-cell]
+
+# For static rendering - can safely be ignored if running notebook interactively
+from pathlib import Path
+
+screenshot_path = Path("../_static/_generated")
+screenshot_path.mkdir(parents=True, exist_ok=True)
+nim.screenshot(
+    path=screenshot_path / "napari_celltype_layers.png",
+    canvas_only=False,
+);
+```
+
+<center>
+  <img src="../_static/_generated/napari_celltype_layers.png"
+       alt="Napari window of multiplexed image with celltype predictions"
+       width=100%
+  />
+</center>
 
 [hubmap-data-portal]: https://portal.hubmapconsortium.org/search/datasets
 [zarr]: https://zarr.readthedocs.io/en/stable/


### PR DESCRIPTION
## Problem

A user reports that the tutorial "stripped out the important steps to run/visualize the results," comparing against `616d4b5`.

They're right. The v0.1.0 monorepo merge (`4a2d7ba`) replaced **both** napari screenshot cells and **both** embedded result images with prose:

> The image and segmentation layers appear directly in the interactive Napari viewer. Static documentation builds do not execute or embed GUI screenshots.

So the tutorial's two visual payoffs — the multiplexed image with the CellSAM segmentation overlaid, and the per-cell-type label layers — disappeared from the rendered page. Both "Visualizing results" sections now end with no output at all.

## Why the premise was wrong

napari *does* render headlessly (Xvfb + llvmpipe), and that is how the currently-deployed site was built. https://vanvalenlab.github.io/deepcell-types/site/tutorial.html still serves both images today:

- `_static/_generated/napari_img_and_segmentation.png`
- `_static/_generated/napari_celltype_layers.png`

The repo source and the published build had silently diverged. This restores the source to match the build that actually works.

## Change

Restores the two `hide-cell` `nim.screenshot(...)` cells and the two `<img>` embeds. Docs-only; no code touched.

## Verification

- `jupytext` parses the tutorial: 45 cells / 24 code cells, 2 screenshot cells, 2 image embeds
- `pytest`: 470 passed, 1 skipped
- Resulting `docs/site/tutorial.md` is byte-identical to the version that produced the live site, apart from one unrelated abstention-wording sentence left untouched

## Not addressed here

The same report also says the model won't run. Everything testable offline is healthy — `pip install git+...@master` resolves (incl. `deepcell_auth` from git), the deepcell-auth manifest maps `2026-06-15` to `models/deepcell-types_2026-06-15_resmlp.pt` / `b819a7e0…`, and `predict()` runs fine against that checkpoint on this branch. The one link that can't be checked without a token is whether the bucket actually serves an asset with that hash. Tracking separately.

Separately: gh-pages was last built 2026-07-12, which **predates** the deepcell-auth migration (#47, 2026-07-30) — the published site should be rebuilt from master once this lands.